### PR TITLE
portal: Only derive key if needed

### DIFF
--- a/src/portal/api/encrypted_item.rs
+++ b/src/portal/api/encrypted_item.rs
@@ -19,7 +19,7 @@ pub(crate) struct EncryptedItem {
 
 impl EncryptedItem {
     pub async fn decrypt(mut self, key_ext: impl KeyExt) -> Result<Item, Error> {
-        let key = key_ext.get().await;
+        let key = key_ext.key().await;
         let mac_tag = self.blob.split_off(self.blob.len() - MacAlg::output_size());
 
         // verify item

--- a/src/portal/api/encrypted_item.rs
+++ b/src/portal/api/encrypted_item.rs
@@ -5,7 +5,7 @@ use digest::{Mac, OutputSizeUser};
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::Type;
 
-use super::{Error, Item};
+use super::{super::KeyExt, Error, Item};
 use crate::{
     crypto::{self, DecAlg, MacAlg},
     Key,
@@ -18,7 +18,8 @@ pub(crate) struct EncryptedItem {
 }
 
 impl EncryptedItem {
-    pub fn decrypt(mut self, key: &Key) -> Result<Item, Error> {
+    pub async fn decrypt(mut self, key_ext: impl KeyExt) -> Result<Item, Error> {
+        let key = key_ext.get().await;
         let mac_tag = self.blob.split_off(self.blob.len() - MacAlg::output_size());
 
         // verify item

--- a/src/portal/item.rs
+++ b/src/portal/item.rs
@@ -90,7 +90,7 @@ impl Item {
     }
 
     pub(crate) async fn encrypt(&self, key_ext: impl KeyExt) -> Result<EncryptedItem, Error> {
-        let key = key_ext.get().await;
+        let key = key_ext.key().await;
         let decrypted = Zeroizing::new(zvariant::to_bytes(*GVARIANT_ENCODING, &self)?);
 
         let iv = crypto::generate_iv();


### PR DESCRIPTION
This allows for searches that find nothing or number of items
operations to complete without deriving the key.

I think with this one I wouldn't need the unstable feature anymore.