### PR TITLE
Use std::sync::OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["keyring", "secret", "service", "portal", "keychain"]
 exclude = ["org.freedesktop.Secrets.xml"]
 categories = ["os::linux-apis", "os", "api-bindings"]
 license = "MIT"
+rust-version = "1.70"
 
 [dependencies]
 zbus = {version = "3.5.0", default-features = false, features = ["gvariant"]}

--- a/README.md
+++ b/README.md
@@ -60,13 +60,13 @@ async fn run() -> oo7::Result<()> {
 }
 ```
 
-If your application makes heavy usage of the keyring like a password manager. You could store an instance of the `Keyring` in a `OnceCell`
+If your application makes heavy usage of the keyring like a password manager. You could store an instance of the `Keyring` in a `OnceLock`
 
 ```rust,ignore
-use once_cell::sync::OnceCell;
 use std::collections::HashMap;
+use std::sync::OnceLock;
 
-static KEYRING: OnceCell<oo7::Keyring> = OnceCell::new();
+static KEYRING: OnceLock<oo7::Keyring> = OnceLock::new();
 
 fn main() {
     // SOME_RUNTIME could be a tokio/async-std/glib runtime

--- a/examples/basic_2.rs
+++ b/examples/basic_2.rs
@@ -1,9 +1,8 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::OnceLock};
 
-use once_cell::sync::OnceCell;
 use oo7::Keyring;
 
-static KEYRING: OnceCell<Keyring> = OnceCell::new();
+static KEYRING: OnceLock<Keyring> = OnceLock::new();
 
 #[async_std::main]
 async fn main() -> oo7::Result<()> {

--- a/src/portal/mod.rs
+++ b/src/portal/mod.rs
@@ -31,12 +31,11 @@
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
-    sync::Arc,
+    sync::{Arc, OnceLock},
 };
 
 #[cfg(feature = "async-std")]
 use async_std::{fs, io, prelude::*, sync::RwLock};
-use once_cell::sync::OnceCell;
 #[cfg(feature = "tokio")]
 use tokio::{fs, io, io::AsyncReadExt, sync::RwLock};
 use zeroize::Zeroizing;
@@ -66,7 +65,7 @@ pub struct Keyring {
     /// Times are stored before reading the file to detect
     /// file changes before writing
     mtime: RwLock<Option<std::time::SystemTime>>,
-    key: RwLock<OnceCell<Key>>,
+    key: RwLock<OnceLock<Key>>,
     secret: Arc<Secret>,
 }
 
@@ -288,7 +287,7 @@ impl Keyring {
     }
 
     /// Return key, derive and store it first if not initialized
-    async fn derive_key<'a>(&'a self, key: &'a mut OnceCell<Key>) -> &'a Key {
+    async fn derive_key<'a>(&'a self, key: &'a mut OnceLock<Key>) -> &'a Key {
         let keyring = Arc::clone(&self.keyring);
         let secret = Arc::clone(&self.secret);
 


### PR DESCRIPTION
Its too early to merge this, so ill mark as draft, at least until around the time the dependency is not needed  by gtk-rs-core.