### PR TITLE
portal: Drop dirs dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ sha2 = {version = "0.10", optional = true}
 openssl = {version = "0.10", optional = true}
 
 once_cell = "1.9"
-dirs = "5.0"
 
 [dev-dependencies]
 async-std = {version = "1.11", features = ["attributes"]}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,22 @@
+use std::path::PathBuf;
+
 #[cfg(feature = "async-std")]
 use async_std::{fs::File, prelude::*};
 #[cfg(feature = "tokio")]
 use tokio::{fs::File, io::AsyncReadExt};
+
+pub(crate) fn data_dir() -> Option<PathBuf> {
+    std::env::var_os("XDG_DATA_HOME")
+        .and_then(|h| if h.is_empty() { None } else { Some(h) })
+        .map(PathBuf::from)
+        .and_then(|p| if p.is_absolute() { Some(p) } else { None })
+        .or_else(|| {
+            std::env::var_os("HOME")
+                .and_then(|h| if h.is_empty() { None } else { Some(h) })
+                .map(PathBuf::from)
+                .map(|p| p.join(".local/share"))
+        })
+}
 
 pub(crate) async fn is_flatpak() -> bool {
     #[cfg(feature = "async-std")]

--- a/src/portal/api/mod.rs
+++ b/src/portal/api/mod.rs
@@ -233,7 +233,7 @@ impl Keyring {
     }
 
     pub fn default_path() -> Result<PathBuf, Error> {
-        if let Some(mut path) = dirs::data_dir() {
+        if let Some(mut path) = crate::helpers::data_dir() {
             path.push("keyrings");
             path.push("default.keyring");
             Ok(path)


### PR DESCRIPTION
We only use that for getting the xdg data dir which can be pretty easily retrieved in the platforms we care about

cc @sophie-h 