### PR TITLE
wip: secret-server backend implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "client",
   "cli",
   "portal",
+  "daemon",
 ]
 
 [workspace.package]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "oo7-daemon"
+edition.workspace = true
+exclude.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+version.workspace = true
+
+[dependencies]
+oo7 = { path = "../client", features = ["unstable"] }
+serde = "1.0"
+tokio = { version = "1", features = ["full"] } # look for specific features
+zbus = "3.14.1"
+zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -11,4 +11,4 @@ version.workspace = true
 oo7 = { path = "../client", features = ["unstable"] }
 serde = "1.0"
 tokio = { version = "1", features = ["full"] } # look for specific features
-zbus = "3.14.1"
+zbus = "4.0.0"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -12,4 +12,3 @@ oo7 = { path = "../client", features = ["unstable"] }
 serde = "1.0"
 tokio = { version = "1", features = ["full"] } # look for specific features
 zbus = "3.14.1"
-zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -1,0 +1,44 @@
+pub mod service;
+
+use std::{future::pending, sync::OnceLock};
+
+use oo7::portal::Keyring;
+use zbus::{ConnectionBuilder, Result};
+
+const SECRET_SERVICE_OBJECTPATH: &str = "/org/freedesktop/secrets_";
+// const SECRET_COLLECTION_OBJECTPATH: &str =
+// "/org/freedesktop/secrets_/collection"; const SECRET_SESSION_OBJECTPATH: &str
+// = "/org/freedesktop/secrets_/session";
+
+use crate::service::service::Service;
+
+pub static KEYRING: OnceLock<Keyring> = OnceLock::new();
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let secret_service = Service {
+        collections: Vec::new(),
+    };
+
+    // let collection = Collection::default();
+    // let session = Session {
+    // path: ObjectPath::default().into(),
+    // };
+
+    let _service = ConnectionBuilder::session()?
+        .name("org.freedesktop.secrets_")?
+        .serve_at(SECRET_SERVICE_OBJECTPATH, secret_service)?
+        //.serve_at(SECRET_COLLECTION_OBJECTPATH, collection)?
+        //.serve_at(SECRET_SESSION_OBJECTPATH, session)?
+        .build()
+        .await?;
+
+    let _keyring = match Keyring::load_default().await {
+        Ok(keyring) => KEYRING.set(keyring),
+        Err(_) => todo!(), // call some init to create default keyring
+    };
+
+    pending::<()>().await;
+
+    Ok(())
+}

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -6,37 +6,21 @@ use oo7::portal::Keyring;
 use zbus::{ConnectionBuilder, Result};
 
 const SECRET_SERVICE_OBJECTPATH: &str = "/org/freedesktop/secrets_";
-// const SECRET_COLLECTION_OBJECTPATH: &str =
-// "/org/freedesktop/secrets_/collection"; const SECRET_SESSION_OBJECTPATH: &str
-// = "/org/freedesktop/secrets_/session";
 
 use crate::service::service::Service;
 
 pub static KEYRING: OnceLock<Keyring> = OnceLock::new();
+// TODO remove this and use service::keyring()
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let secret_service = Service {
-        collections: Vec::new(),
-    };
-
-    // let collection = Collection::default();
-    // let session = Session {
-    // path: ObjectPath::default().into(),
-    // };
+    let service = Service::new().await;
 
     let _service = ConnectionBuilder::session()?
         .name("org.freedesktop.secrets_")?
-        .serve_at(SECRET_SERVICE_OBJECTPATH, secret_service)?
-        //.serve_at(SECRET_COLLECTION_OBJECTPATH, collection)?
-        //.serve_at(SECRET_SESSION_OBJECTPATH, session)?
+        .serve_at(SECRET_SERVICE_OBJECTPATH, service)?
         .build()
         .await?;
-
-    let _keyring = match Keyring::load_default().await {
-        Ok(keyring) => KEYRING.set(keyring),
-        Err(_) => todo!(), // call some init to create default keyring
-    };
 
     pending::<()>().await;
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -3,9 +3,7 @@ pub mod service;
 use std::{future::pending, sync::OnceLock};
 
 use oo7::portal::Keyring;
-use zbus::{ConnectionBuilder, Result};
-
-const SECRET_SERVICE_OBJECTPATH: &str = "/org/freedesktop/secrets_";
+use zbus::Result;
 
 use crate::service::service::Service;
 
@@ -15,12 +13,7 @@ pub static KEYRING: OnceLock<Keyring> = OnceLock::new();
 #[tokio::main]
 async fn main() -> Result<()> {
     let service = Service::new().await;
-
-    let _service = ConnectionBuilder::session()?
-        .name("org.freedesktop.secrets_")?
-        .serve_at(SECRET_SERVICE_OBJECTPATH, service)?
-        .build()
-        .await?;
+    service.run().await?;
 
     pending::<()>().await;
 

--- a/daemon/src/service/collection.rs
+++ b/daemon/src/service/collection.rs
@@ -100,6 +100,10 @@ impl Collection {
         &self.alias
     }
 
+    pub fn set_alias(&mut self, alias: String) {
+        self.alias = alias;
+    }
+
     #[zbus(signal)]
     pub async fn item_created(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 

--- a/daemon/src/service/collection.rs
+++ b/daemon/src/service/collection.rs
@@ -12,7 +12,7 @@ use crate::{service::item, KEYRING};
 #[derive(Default, Debug, Type)]
 #[zvariant(signature = "o")]
 pub struct Collection {
-    pub items: Vec<item::Item>,
+    items: Vec<item::Item>,
     label: String,
     locked: bool,
     created: u64,

--- a/daemon/src/service/collection.rs
+++ b/daemon/src/service/collection.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use oo7::{dbus::api::Properties, portal::Item};
 use serde::{Serialize, Serializer};
-use zbus::{dbus_interface, zvariant, Error, ObjectServer, SignalContext};
+use zbus::{interface, zvariant, Error, ObjectServer, SignalContext};
 use zvariant::{ObjectPath, OwnedObjectPath, Type};
 
 use crate::{service::item, KEYRING};
@@ -20,7 +20,7 @@ pub struct Collection {
     path: OwnedObjectPath,
 }
 
-#[dbus_interface(name = "org.freedesktop.Secret.Collection")]
+#[interface(name = "org.freedesktop.Secret.Collection")]
 impl Collection {
     pub async fn delete(&self, #[zbus(object_server)] object_server: &ObjectServer) -> ObjectPath {
         let _ = object_server.remove::<Collection, _>(&self.path).await;
@@ -64,38 +64,38 @@ impl Collection {
         (created_item_path, prompt)
     }
 
-    #[dbus_interface(property, name = "Items")]
+    #[zbus(property, name = "Items")]
     pub fn items(&self) -> Vec<ObjectPath> {
         self.items.iter().map(|item| item.path()).collect()
     }
 
-    #[dbus_interface(property, name = "Label")]
+    #[zbus(property, name = "Label")]
     pub fn label(&self) -> &str {
         &self.label
     }
 
-    #[dbus_interface(property, name = "Locked")]
+    #[zbus(property, name = "Locked")]
     pub fn locked(&self) -> bool {
         self.locked
     }
 
-    #[dbus_interface(property, name = "Created")]
+    #[zbus(property, name = "Created")]
     pub fn created(&self) -> u64 {
         self.created
     }
 
-    #[dbus_interface(property, name = "Modified")]
+    #[zbus(property, name = "Modified")]
     pub fn modified(&self) -> u64 {
         self.modified
     }
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn item_created(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn item_deleted(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn item_changed(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 }
 

--- a/daemon/src/service/collection.rs
+++ b/daemon/src/service/collection.rs
@@ -1,0 +1,167 @@
+// org.freedesktop.Secret.Collection
+
+use std::collections::HashMap;
+
+use oo7::{dbus::api::Properties, portal::Item};
+use serde::{Serialize, Serializer};
+use zbus::{dbus_interface, zvariant, Error, ObjectServer, SignalContext};
+use zvariant::{ObjectPath, OwnedObjectPath, Type};
+
+use crate::{service::item, KEYRING};
+
+#[derive(Default, Debug, Type)]
+#[zvariant(signature = "o")]
+pub struct Collection {
+    pub items: Vec<item::Item>,
+    label: String,
+    locked: bool,
+    created: u64, // how to represent date
+    modified: u64,
+    path: OwnedObjectPath,
+}
+
+#[dbus_interface(name = "org.freedesktop.Secret.Collection")]
+impl Collection {
+    pub async fn delete(&self, #[zbus(object_server)] object_server: &ObjectServer) -> ObjectPath {
+        let _ = object_server.remove::<Collection, _>(&self.path).await;
+        ObjectPath::default().into() // returning '/' until we figure out Prompt
+    }
+
+    pub async fn search_items(&self, attributes: HashMap<&str, &str>) -> Vec<Item> {
+        let items = match KEYRING.get().unwrap().search_items(&attributes).await {
+            Ok(i) => i,
+            Err(_) => todo!(),
+        };
+
+        items // currently returns Vec<oo7::portal::Item>, this should be a path
+    }
+
+    pub async fn create_item(
+        &mut self,
+        properties: Properties,
+        secret: &str,
+        replace: bool,
+    ) -> (ObjectPath, ObjectPath) {
+        let label = properties.label();
+        let mut attributes: HashMap<&str, &str> = Default::default();
+
+        for (key, value) in properties.attributes().unwrap().into_iter() {
+            attributes.insert(key.as_str(), value.as_str());
+        }
+
+        match KEYRING
+            .get()
+            .unwrap()
+            .create_item(label, attributes.clone(), secret, replace)
+            .await
+        {
+            Ok(_) => (),
+            Err(_) => (), // best approach to handle this error?
+        }
+
+        // lookup just created item
+        let lookup_item = KEYRING
+            .get()
+            .unwrap()
+            .lookup_item(&attributes)
+            .await
+            .unwrap()
+            .unwrap();
+        // make prompt to get the secret and set it with set_secret()
+
+        let created_item_path = ObjectPath::default().into(); // how to get path from _collection
+        let prompt = ObjectPath::default().into(); // temp Prompt
+
+        let mut attributes_for_new: HashMap<&str, &str> = Default::default();
+        for (key, value) in lookup_item.attributes() {
+            attributes_for_new.insert(key.as_str(), value);
+        }
+
+        // TODO map portal::Item to crate::Item and push it to items attribute
+        let item = item::Item::new(
+            &attributes_for_new,
+            lookup_item.secret().to_vec(),
+            lookup_item.label(),
+            lookup_item.created().as_secs(),
+            lookup_item.modified().as_secs(),
+            self.path().to_owned().into(),
+        )
+        .await;
+        self.items.push(item);
+
+        (created_item_path, prompt)
+    }
+
+    #[dbus_interface(property, name = "Items")]
+    pub fn items(&self) -> Vec<ObjectPath> {
+        self.items.iter().map(|item| item.path()).collect()
+    }
+
+    #[dbus_interface(property, name = "Label")]
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    #[dbus_interface(property, name = "Locked")]
+    pub fn locked(&self) -> bool {
+        self.locked
+    }
+
+    #[dbus_interface(property, name = "Created")]
+    pub fn created(&self) -> u64 {
+        self.created
+    }
+
+    #[dbus_interface(property, name = "Modified")]
+    pub fn modified(&self) -> u64 {
+        self.modified
+    }
+
+    #[dbus_interface(signal)]
+    pub async fn item_created(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+
+    #[dbus_interface(signal)]
+    pub async fn item_deleted(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+
+    #[dbus_interface(signal)]
+    pub async fn item_changed(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+}
+
+impl Serialize for Collection {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        OwnedObjectPath::serialize(&self.path, serializer)
+    }
+}
+
+impl Collection {
+    // temporarily creates a generic Collection object
+    pub fn new(label: &str) -> Self {
+        Self {
+            items: Vec::new(),
+            label: label.to_owned(),
+            locked: false,
+            created: 23123,
+            modified: 23123,
+            path: OwnedObjectPath::try_from(format!(
+                "/org/freedesktop/secrets/collection/{}",
+                label
+            ))
+            .unwrap(),
+        }
+    }
+
+    pub fn path(&self) -> ObjectPath {
+        self.path.to_owned().into()
+    }
+
+    pub async fn set_label(&mut self, label: String) {
+        self.label = label;
+    }
+
+    pub async fn set_locked(&mut self, locked: bool) {
+        self.locked = locked;
+    }
+}

--- a/daemon/src/service/item.rs
+++ b/daemon/src/service/item.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use oo7::portal;
 use portal::api::AttributeValue;
-use zbus::{dbus_interface, fdo, zvariant, ObjectServer};
+use zbus::{fdo, interface, zvariant, ObjectServer};
 use zvariant::{ObjectPath, OwnedObjectPath};
 
 use crate::KEYRING;
@@ -15,7 +15,7 @@ pub struct Item {
     path: OwnedObjectPath,
 }
 
-#[dbus_interface(name = "org.freedesktop.Secret.Item")]
+#[interface(name = "org.freedesktop.Secret.Item")]
 impl Item {
     pub async fn delete(
         &mut self,

--- a/daemon/src/service/item.rs
+++ b/daemon/src/service/item.rs
@@ -1,0 +1,129 @@
+// org.freedesktop.Secret.Item
+
+use std::collections::HashMap;
+
+use oo7::dbus::api::Properties;
+use zbus::{dbus_interface, fdo, zvariant, ObjectServer};
+use zeroize::Zeroize;
+use zvariant::{ObjectPath, OwnedObjectPath};
+
+use crate::KEYRING;
+
+#[derive(Debug, Zeroize)]
+pub struct Item {
+    #[zeroize(skip)]
+    locked: bool,
+    #[zeroize(skip)]
+    properties: Properties,
+    #[zeroize(skip)]
+    created: u64,
+    #[zeroize(skip)]
+    modified: u64,
+    secret: Vec<u8>,
+    #[zeroize(skip)]
+    path: OwnedObjectPath,
+}
+
+#[dbus_interface(name = "org.freedesktop.Secret.Item")]
+impl Item {
+    pub async fn delete(
+        &self,
+        #[zbus(object_server)] object_server: &ObjectServer,
+    ) -> fdo::Result<ObjectPath> {
+        let mut properties: HashMap<&str, &str> = Default::default();
+
+        for (key, value) in self.properties().attributes().unwrap().into_iter() {
+            properties.insert(key.as_str(), value.as_str());
+        }
+
+        let _ = KEYRING.get().unwrap().delete(&properties).await;
+        let _ = object_server.remove::<Item, _>(self.path()).await;
+        Ok(ObjectPath::default().into())
+    }
+
+    pub async fn get_secret(&self /* session: Session */) -> fdo::Result<Vec<u8>> {
+        let item = KEYRING
+            .get()
+            .unwrap()
+            .lookup_item(&self.lookup_item_attributes().await)
+            .await
+            .unwrap()
+            .unwrap();
+        // do something with session parameter
+        Ok(item.secret().to_vec())
+    }
+
+    pub async fn set_secret(&self, secret: Vec<u8>) {
+        let mut item = KEYRING
+            .get()
+            .unwrap()
+            .lookup_item(&self.lookup_item_attributes().await)
+            .await
+            .unwrap()
+            .unwrap();
+
+        item.set_secret(secret)
+    }
+
+    pub fn locked(&self) -> bool {
+        self.locked
+    }
+
+    pub fn properties(&self) -> &Properties {
+        &self.properties
+    }
+
+    pub fn label(&self) -> &str {
+        let attributes = self.properties();
+        attributes.label()
+    }
+
+    pub fn created(&self) -> u64 {
+        self.created
+    }
+
+    pub fn modified(&self) -> u64 {
+        self.created
+    }
+
+    pub fn path(&self) -> ObjectPath {
+        self.path.to_owned().into()
+    }
+}
+
+impl Item {
+    pub async fn new(
+        attributes: &HashMap<&str, &str>,
+        secret: Vec<u8>,
+        label: &str,
+        created: u64,
+        modified: u64,
+        collection_path: OwnedObjectPath,
+    ) -> Self {
+        // maps oo7::portal::Item to crate Item
+        let properties = Properties::for_item(label, attributes);
+        Self {
+            locked: true,
+            properties: properties,
+            created: created,
+            modified: modified,
+            secret: secret,
+            path: OwnedObjectPath::try_from(format!(
+                "{}/items/{}",
+                collection_path.as_str(),
+                label
+            ))
+            .unwrap(),
+        }
+    }
+
+    pub async fn lookup_item_attributes(&self) -> HashMap<&str, &str> {
+        let mut attributes: HashMap<&str, &str> = Default::default();
+
+        for (key, value) in self.properties().attributes().unwrap().into_iter() {
+            attributes.insert(key.as_str(), value.as_str());
+        }
+
+        attributes
+    }
+}

--- a/daemon/src/service/item.rs
+++ b/daemon/src/service/item.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use oo7::{portal};
+use oo7::portal;
 use portal::api::AttributeValue;
 use zbus::{dbus_interface, fdo, zvariant, ObjectServer};
 use zvariant::{ObjectPath, OwnedObjectPath};
@@ -36,9 +36,9 @@ impl Item {
         self.inner().set_secret(secret);
     }
 
-    /*pub fn locked(&self) -> bool {
-        self.locked
-    }*/
+    // pub fn locked(&self) -> bool {
+    // self.locked
+    // }
 
     pub fn attributes(&mut self) -> &HashMap<String, AttributeValue> {
         self.inner().attributes()
@@ -62,10 +62,7 @@ impl Item {
 }
 
 impl Item {
-    pub async fn new(
-        item: portal::Item,
-        collection_path: OwnedObjectPath,
-    ) -> Self {
+    pub async fn new(item: portal::Item, collection_path: OwnedObjectPath) -> Self {
         // maps oo7::portal::Item to crate::service::Item
         Self {
             inner: item.to_owned(),

--- a/daemon/src/service/mod.rs
+++ b/daemon/src/service/mod.rs
@@ -1,0 +1,4 @@
+mod collection;
+mod item;
+pub mod service;
+mod session;

--- a/daemon/src/service/service.rs
+++ b/daemon/src/service/service.rs
@@ -63,9 +63,6 @@ impl Service {
         Ok((path, prompt))
     }
 
-    // I have updated the collection interface impl. So, I need to re check everything starting
-    // here
-    /*
     #[zbus(out_args("unlocked", "locked"))]
     pub async fn search_items(
         &self,
@@ -93,6 +90,7 @@ impl Service {
         Ok((unlocked, locked))
     }
 
+    /*
     #[zbus(out_args("unlocked", "prompt"))]
     pub async fn unlock(
         &mut self,
@@ -167,28 +165,36 @@ impl Service {
                 if in_collection.path().as_str() == item.as_str() {}
             }
         }
-    }
+    }*/
 
     pub async fn read_alias(&self, name: &str) -> ObjectPath {
-        let mut ret = ObjectPath::default();
+        let mut path = ObjectPath::default();
         for collection in &self.collections {
-            if collection.label() == name {
-                ret = collection.path().into();
+            if collection.alias() == name {
+                path = collection.path().into();
             }
         }
 
-        ret
+        path
     }
 
-    pub async fn set_alias(&mut self, name: String, collection: OwnedObjectPath) {
-        // WIP: not complete:: handle alias
-        for in_collection in &mut self.collections {
-            if in_collection.path().as_str() == collection.as_str() {
-                in_collection.set_label(name.clone()).await;
+    pub async fn set_alias(&mut self, name: String, collection_path: OwnedObjectPath) {
+        // handle "default" aliais
+        if name == "default" {
+            return; // return Err
+        }
+
+        // handle "/" ObjectPath
+        if collection_path.as_str() == "/" {
+            return; // return Err
+        }
+
+        for collection in &mut self.collections {
+            if collection.path() == collection_path.as_str() {
+                collection.set_alias(name.clone());
             }
         }
     }
-    */
 
     #[zbus(property, name = "Collections")]
     pub fn collections(&self) -> Vec<ObjectPath> {

--- a/daemon/src/service/service.rs
+++ b/daemon/src/service/service.rs
@@ -1,0 +1,191 @@
+//  org.freedesOnceCellktop.Secret.Service
+
+use std::collections::HashMap;
+
+use oo7::{dbus::api::Properties, portal::Item};
+use serde::Serialize;
+use zbus::{dbus_interface, fdo, zvariant, Error, ObjectServer, SignalContext};
+use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
+
+use crate::{
+    service::{collection::Collection, session::Session},
+    KEYRING,
+};
+
+#[derive(Serialize, Type, Debug)]
+pub struct Service {
+    pub collections: Vec<Collection>,
+}
+
+#[dbus_interface(name = "org.freedesktop.Secret.Service")]
+impl Service {
+    pub async fn open_session(
+        &self,
+        // algorithm: &str,
+        input: Value<'_>,
+    ) -> fdo::Result<(OwnedValue, OwnedObjectPath)> {
+        // WIP: not complete
+        let session = Session::new(ObjectPath::try_from("/s1").unwrap().into()).await;
+        Ok((
+            OwnedValue::try_from(input).unwrap(), // avoid using unwrap
+            ObjectPath::try_from(session.path().await).unwrap().into(),
+        ))
+    }
+
+    #[dbus_interface(out_args("collection", "prompt"))]
+    pub async fn create_collection(
+        &self,
+        properties: Properties,
+        alias: String,
+        #[zbus(object_server)] object_server: &ObjectServer,
+    ) -> fdo::Result<(ObjectPath, ObjectPath)> {
+        let _attributes = properties.attributes(); // expand and pass these to Collection:new
+        let collection = Collection::new("temp"); // temporarily
+        let path = format!("/org/freedesktop/secrets_/collection/{}", &alias);
+
+        let _ = object_server.at(path.clone(), collection).await;
+        let new_collection_path = ObjectPath::try_from(path).unwrap(); // temporarily
+        let prompt = ObjectPath::default().into(); // temp Prompt
+
+        Ok((new_collection_path, prompt))
+    }
+
+    #[dbus_interface(out_args("unlocked", "locked"))]
+    pub async fn search_items(
+        &self,
+        attributes: HashMap<&str, &str>,
+    ) -> fdo::Result<(Vec<Item>, Vec<Item>)> {
+        let items = match KEYRING.get().unwrap().search_items(&attributes).await {
+            Ok(i) => i,
+            Err(_) => todo!(),
+        };
+
+        let mut unlocked: Vec<Item> = Vec::new();
+        let mut locked: Vec<Item> = Vec::new();
+
+        for item in items {
+            let attributes = item.attributes();
+            if attributes.get("locked").is_some() {
+                // this if condition is probably wrong
+                // how to access &AttributeValue value
+                locked.push(item)
+            } else {
+                unlocked.push(item)
+            }
+        }
+
+        Ok((unlocked, locked))
+    }
+
+    #[dbus_interface(out_args("unlocked", "prompt"))]
+    pub async fn unlock(
+        &mut self,
+        objects: Vec<OwnedObjectPath>,
+    ) -> fdo::Result<(Vec<OwnedObjectPath>, OwnedObjectPath)> {
+        // manage unlock state in memory
+        // when do we need to prompt?
+        let mut unlocked: Vec<OwnedObjectPath> = Vec::new();
+
+        'main: for object in objects {
+            for collection in &mut self.collections {
+                if collection.path().as_str() == object.as_str() {
+                    if collection.locked() {
+                        collection.set_locked(false).await;
+                        unlocked.push(object.clone());
+                    } else {
+                        break 'main;
+                    }
+                }
+            }
+        }
+
+        if unlocked.len() == 0 {
+            unlocked.push(ObjectPath::default().into());
+        }
+
+        let prompt = ObjectPath::default().into(); // temporarily
+
+        Ok((unlocked, prompt))
+    }
+
+    #[dbus_interface(out_args("locked", "prompt"))]
+    pub async fn lock(
+        &mut self,
+        objects: Vec<OwnedObjectPath>,
+    ) -> fdo::Result<(Vec<OwnedObjectPath>, OwnedObjectPath)> {
+        // manage lock state in memory
+        // when do we need to prompt?
+        let mut locked: Vec<OwnedObjectPath> = Vec::new();
+
+        for object in objects {
+            for collection in &mut self.collections {
+                if collection.path().as_str() == object.as_str() {
+                    if !collection.locked() {
+                        collection.set_locked(true).await;
+                        locked.push(object.clone());
+                    }
+                }
+            }
+        }
+
+        if locked.len() == 0 {
+            locked.push(ObjectPath::default().into());
+        }
+
+        let prompt = ObjectPath::default().into(); // temporarily
+
+        Ok((locked, prompt))
+    }
+
+    pub async fn get_secrets(&self, items: Vec<OwnedObjectPath>) {
+        // WIP: not complete
+        if KEYRING.get().unwrap().n_items().await == 0 {
+            return;
+        }
+
+        // call item iface get_secret multiple times ?
+
+        for in_collection in &self.collections {
+            for item in &items {
+                if in_collection.path().as_str() == item.as_str() {}
+            }
+        }
+    }
+
+    pub async fn read_alias(&self, name: &str) -> ObjectPath {
+        let mut ret = ObjectPath::default();
+        for collection in &self.collections {
+            if collection.label() == name {
+                ret = collection.path().into();
+            }
+        }
+
+        ret
+    }
+
+    pub async fn set_alias(&mut self, name: String, collection: OwnedObjectPath) {
+        // WIP: not complete:: handle alias
+        for in_collection in &mut self.collections {
+            if in_collection.path().as_str() == collection.as_str() {
+                in_collection.set_label(name.clone()).await;
+            }
+        }
+    }
+
+    #[dbus_interface(property, name = "Collections")]
+    pub fn collections(&self) -> Vec<ObjectPath> {
+        self.collections
+            .iter()
+            .map(|collection| collection.path())
+            .collect()
+    }
+
+    #[dbus_interface(signal)]
+    pub async fn collection_created(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+
+    #[dbus_interface(signal)]
+    pub async fn collection_deleted(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+
+    #[dbus_interface(signal)]
+    pub async fn collection_changed(ctxt: &SignalContext<'_>) -> Result<(), Error>;
+}

--- a/daemon/src/service/service.rs
+++ b/daemon/src/service/service.rs
@@ -7,7 +7,7 @@ use oo7::{
     portal::{Item, Keyring},
 };
 use serde::Serialize;
-use zbus::{dbus_interface, fdo, zvariant, Error, ObjectServer, SignalContext};
+use zbus::{fdo, interface, zvariant, Error, ObjectServer, SignalContext};
 use zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Value};
 
 use crate::{
@@ -22,7 +22,7 @@ pub struct Service {
     keyring: Arc<Keyring>,
 }
 
-#[dbus_interface(name = "org.freedesktop.Secret.Service")]
+#[interface(name = "org.freedesktop.Secret.Service")]
 impl Service {
     pub async fn open_session(
         &self,
@@ -37,7 +37,7 @@ impl Service {
         ))
     }
 
-    #[dbus_interface(out_args("collection", "prompt"))]
+    #[zbus(out_args("collection", "prompt"))]
     pub async fn create_collection(
         &self,
         properties: Properties,
@@ -55,7 +55,7 @@ impl Service {
         Ok((new_collection_path, prompt))
     }
 
-    #[dbus_interface(out_args("unlocked", "locked"))]
+    #[zbus(out_args("unlocked", "locked"))]
     pub async fn search_items(
         &self,
         attributes: HashMap<&str, &str>,
@@ -82,7 +82,7 @@ impl Service {
         Ok((unlocked, locked))
     }
 
-    #[dbus_interface(out_args("unlocked", "prompt"))]
+    #[zbus(out_args("unlocked", "prompt"))]
     pub async fn unlock(
         &mut self,
         objects: Vec<OwnedObjectPath>,
@@ -113,7 +113,7 @@ impl Service {
         Ok((unlocked, prompt))
     }
 
-    #[dbus_interface(out_args("locked", "prompt"))]
+    #[zbus(out_args("locked", "prompt"))]
     pub async fn lock(
         &mut self,
         objects: Vec<OwnedObjectPath>,
@@ -177,7 +177,7 @@ impl Service {
         }
     }
 
-    #[dbus_interface(property, name = "Collections")]
+    #[zbus(property, name = "Collections")]
     pub fn collections(&self) -> Vec<ObjectPath> {
         self.collections
             .iter()
@@ -185,13 +185,13 @@ impl Service {
             .collect()
     }
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn collection_created(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn collection_deleted(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 
-    #[dbus_interface(signal)]
+    #[zbus(signal)]
     pub async fn collection_changed(ctxt: &SignalContext<'_>) -> Result<(), Error>;
 }
 

--- a/daemon/src/service/session.rs
+++ b/daemon/src/service/session.rs
@@ -1,6 +1,6 @@
 // org.freedesktop.Secret.Session
 
-use zbus::{dbus_interface, fdo, zvariant};
+use zbus::{fdo, interface, zvariant};
 use zvariant::OwnedObjectPath;
 
 #[derive(Debug)]
@@ -8,7 +8,7 @@ pub struct Session {
     pub path: OwnedObjectPath,
 }
 
-#[dbus_interface(name = "org.freedesktop.Secret.Service")]
+#[interface(name = "org.freedesktop.Secret.Service")]
 impl Session {
     pub async fn close(
         &mut self,

--- a/daemon/src/service/session.rs
+++ b/daemon/src/service/session.rs
@@ -1,0 +1,32 @@
+// org.freedesktop.Secret.Session
+
+use zbus::{dbus_interface, fdo, zvariant};
+use zvariant::OwnedObjectPath;
+
+#[derive(Debug)]
+pub struct Session {
+    pub path: OwnedObjectPath,
+}
+
+#[dbus_interface(name = "org.freedesktop.Secret.Service")]
+impl Session {
+    pub async fn close(
+        &mut self,
+        #[zbus(object_server)] object_server: &zbus::ObjectServer,
+    ) -> fdo::Result<()> {
+        object_server
+            .remove::<Self, &OwnedObjectPath>(&self.path)
+            .await?;
+        Ok(())
+    }
+}
+
+impl Session {
+    pub async fn new(path: OwnedObjectPath) -> Self {
+        Self { path }
+    }
+
+    pub async fn path(&self) -> &OwnedObjectPath {
+        &self.path
+    }
+}


### PR DESCRIPTION
# Moved to: https://github.com/bilelmoussaoui/oo7/pull/73

### TODO:

- [ ] Implement the dbus secret service API for oo7 daemon: https://specifications.freedesktop.org/secret-service/latest/ [in progress] 
- [ ]  Add legacy keyring format (version 0) support
- [ ]  Write mock tests based on client oo7 library
- [ ] Test daemon in a real case scenario
- [ ] Squash temporary commits

#### - [ ] Interface implementations:

- [ ] ` org.freedesktop.Secret.Service`:
     #### Service methods:
    - [ ] OpenSession()
    - [x] CreateCollection()
    - [x] SearchItems()
    - [x] Unlock()
    - [x] Lock()
    - [ ] GetSecrets()
    - [x] ReadAlias()
    - [x] SetAlias()
     #### Signals:
   
- [ ] ` org.freedesktop.Secret.Collection`:
    #### Service methods:
    - [x] Delete()
    - [x] SearchItems()
    - [x] CreateItem()
     #### Signals:
    #### Other methods:
    - [ ] load existing keyrings in `.local/share/keyrings/`
    
- [ ] ` org.freedesktop.Secret.Session`:
     #### Service methods:
    - [x] Close()
     #### Signals:

<del> - [ ] ` org.freedesktop.Secret.Prompt`:
  
- [ ] ` org.freedesktop.Secret.Item`:
     #### Service methods:
    - [x] Delete()
    - [x] GetSecret()
    - [x] SetSecret()
    #### Signals:

#### - [x] Interfaces access to Property:
 - [x] `busctl --user get-property`