### PR TITLE
Stop using the async-std crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,9 @@ rust-version = "1.66"
 [dependencies]
 zbus = { version = "3.5.0", default-features = false, features = ["gvariant"] }
 serde = "1.0"
+futures-lite = { version = "2.1", optional = true }
 futures-util = "0.3"
 rand = { version = "0.8", default-features = false }
-async-std = { version = "1.11", optional = true }
-async-global-executor = { version = "2.3", optional = true }
 tokio = { version = "1.17", features = [
     "sync",
     "fs",
@@ -42,6 +41,10 @@ pbkdf2 = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
 openssl = { version = "0.10", optional = true }
 once_cell = "1.9"
+async-fs = { version = "2.1.0", optional = true }
+async-lock = { version = "3.2.0", optional = true }
+async-io = { version = "2.2.2", optional = true }
+blocking = { version = "1.5.1", optional = true }
 
 [dev-dependencies]
 async-std = { version = "1.11", features = ["attributes"] }
@@ -56,7 +59,14 @@ local_tests = []
 unstable = []
 # Build nicer docs (requires nightly)
 docs = []
-async-std = ["zbus/async-io", "dep:async-std", "dep:async-global-executor"]
+async-std = [
+    "zbus/async-io",
+    "dep:async-fs",
+    "dep:async-io",
+    "dep:async-lock",
+    "dep:blocking",
+    "dep:futures-lite",
+]
 tokio = ["zbus/tokio", "dep:tokio"]
 native_crypto = [
     "aes",

--- a/src/dbus/collection.rs
+++ b/src/dbus/collection.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 #[cfg(feature = "async-std")]
-use async_std::sync::RwLock;
+use async_lock::RwLock;
 #[cfg(feature = "tokio")]
 use tokio::sync::RwLock;
 

--- a/src/dbus/item.rs
+++ b/src/dbus/item.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 #[cfg(feature = "async-std")]
-use async_std::sync::RwLock;
+use async_lock::RwLock;
 #[cfg(feature = "tokio")]
 use tokio::sync::RwLock;
 use zeroize::Zeroizing;

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 
 #[cfg(feature = "async-std")]
-use async_std::{fs::File, prelude::*};
+use async_fs::File;
+#[cfg(feature = "async-std")]
+use futures_lite::io::AsyncReadExt;
 #[cfg(feature = "tokio")]
 use tokio::{fs::File, io::AsyncReadExt};
 
@@ -21,9 +23,7 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
 pub(crate) async fn is_flatpak() -> bool {
     #[cfg(feature = "async-std")]
     {
-        async_std::path::PathBuf::from("/.flatpak-info")
-            .exists()
-            .await
+        async_fs::metadata("/.flatpak-info").await.is_ok()
     }
     #[cfg(not(feature = "async-std"))]
     {

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 #[cfg(feature = "async-std")]
-use async_std::sync::RwLock;
+use async_lock::RwLock;
 #[cfg(feature = "tokio")]
 use tokio::sync::RwLock;
 use zeroize::Zeroizing;

--- a/src/portal/api/mod.rs
+++ b/src/portal/api/mod.rs
@@ -6,17 +6,21 @@
 // - Make more things async
 
 #[cfg(feature = "async-std")]
-use std::os::unix::fs::OpenOptionsExt;
+use async_fs::unix::OpenOptionsExt;
+#[cfg(feature = "async-std")]
+use futures_lite::AsyncWriteExt;
 use std::{
     collections::HashMap,
     path::{Path, PathBuf},
 };
 
 #[cfg(feature = "async-std")]
-use async_std::{fs, io, prelude::*};
+use async_fs as fs;
 use once_cell::sync::Lazy;
 use rand::Rng;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "async-std")]
+use std::io;
 #[cfg(feature = "tokio")]
 use tokio::{fs, io, io::AsyncWriteExt};
 use zbus::zvariant::{self, Type};

--- a/src/portal/mod.rs
+++ b/src/portal/mod.rs
@@ -35,12 +35,14 @@ use std::{
 };
 
 #[cfg(feature = "async-std")]
-use async_std::{
-    fs, io,
-    prelude::*,
-    sync::{Mutex, RwLock},
-};
+use async_fs as fs;
+#[cfg(feature = "async-std")]
+use async_lock::{Mutex, RwLock};
+#[cfg(feature = "async-std")]
+use futures_lite::AsyncReadExt;
 use once_cell::sync::OnceCell;
+#[cfg(feature = "async-std")]
+use std::io;
 #[cfg(feature = "tokio")]
 use tokio::{
     fs, io,
@@ -302,8 +304,8 @@ impl Keyring {
         let secret = Arc::clone(&self.secret);
 
         #[cfg(feature = "async-std")]
-        let newkey = async_global_executor::spawn_blocking(move || {
-            async_std::task::block_on(async { keyring.read().await.derive_key(&secret) })
+        let newkey = blocking::unblock(move || {
+            async_io::block_on(async { keyring.read().await.derive_key(&secret) })
         })
         .await;
 


### PR DESCRIPTION
There hasn't been updates for 1 1/2 years and it potentially pulls dependencies that are not needed.

Replace it with the maintained parts that async-std is made of.