### PR TITLE
Use const rather than static for str

### DIFF
--- a/client/src/dbus/api/mod.rs
+++ b/client/src/dbus/api/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) static DESTINATION: &str = "org.freedesktop.secrets";
-pub(crate) static PATH: &str = "/org/freedesktop/secrets";
+pub(crate) const DESTINATION: &str = "org.freedesktop.secrets";
+pub(crate) const PATH: &str = "/org/freedesktop/secrets";
 
 /// A common trait implemented by objects that can be
 /// locked or unlocked. Like [`Collection`] or [`Item`].

--- a/client/src/dbus/api/properties.rs
+++ b/client/src/dbus/api/properties.rs
@@ -3,10 +3,10 @@ use std::collections::HashMap;
 use serde::ser::{Serialize, SerializeMap};
 use zbus::zvariant::{Type, Value};
 
-static ITEM_PROPERTY_LABEL: &str = "org.freedesktop.Secret.Item.Label";
-static ITEM_PROPERTY_ATTRIBUTES: &str = "org.freedesktop.Secret.Item.Attributes";
+const ITEM_PROPERTY_LABEL: &str = "org.freedesktop.Secret.Item.Label";
+const ITEM_PROPERTY_ATTRIBUTES: &str = "org.freedesktop.Secret.Item.Attributes";
 
-static COLLECTION_PROPERTY_LABEL: &str = "org.freedesktop.Secret.Collection.Label";
+const COLLECTION_PROPERTY_LABEL: &str = "org.freedesktop.Secret.Collection.Label";
 
 #[derive(Debug, Type)]
 #[zvariant(signature = "a{sv}")]

--- a/client/src/dbus/mod.rs
+++ b/client/src/dbus/mod.rs
@@ -35,12 +35,12 @@
 /// The default collection alias.
 ///
 /// In general, you are supposed to use [`Service::default_collection`].
-pub static DEFAULT_COLLECTION: &str = "default";
+pub const DEFAULT_COLLECTION: &str = "default";
 
 /// A session collection.
 ///
 /// The collection is cleared when the user ends the session.
-pub static SESSION_COLLECTION: &str = "session";
+pub const SESSION_COLLECTION: &str = "session";
 
 /// Barebone DBus API of the Secret Service specifications.
 ///


### PR DESCRIPTION
A static is like a const that can be mutated, we don't do that.