### PR TITLE
client/dbus: Add API to create an ecrypted service or fallback

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -6,10 +6,7 @@ use std::{
 };
 
 use clap::{Command, CommandFactory, FromArgMatches, Parser};
-use oo7::{
-    dbus::{Algorithm, Collection, Service},
-    zbus,
-};
+use oo7::dbus::{Collection, Service};
 
 const BINARY_NAME: &'static str = env!("CARGO_BIN_NAME");
 
@@ -271,14 +268,7 @@ async fn print_item<'a>(item: &oo7::dbus::Item<'a>) -> Result<(), Error> {
 }
 
 async fn collection<'a>() -> Result<Collection<'a>, Error> {
-    let service = match Service::new(Algorithm::Encrypted).await {
-        Ok(service) => Ok(service),
-        Err(oo7::dbus::Error::Zbus(zbus::Error::MethodError(_, _, _))) => {
-            Service::new(Algorithm::Plain).await
-        }
-        Err(e) => Err(e),
-    }?;
-
+    let service = Service::new().await?;
     let collection = match service.default_collection().await {
         Ok(c) => Ok(c),
         Err(oo7::dbus::Error::NotFound(_)) => {

--- a/client/examples/dbus_service.rs
+++ b/client/examples/dbus_service.rs
@@ -1,10 +1,10 @@
 use std::collections::HashMap;
 
-use oo7::dbus::{Algorithm, Service};
+use oo7::dbus::Service;
 
 #[async_std::main]
 async fn main() -> oo7::Result<()> {
-    let service = Service::new(Algorithm::Plain).await?;
+    let service = Service::new().await?;
 
     let mut attributes = HashMap::new();
     attributes.insert("type", "token");

--- a/client/src/dbus/collection.rs
+++ b/client/src/dbus/collection.rs
@@ -310,14 +310,14 @@ mod tests {
     #[async_std::test]
     #[cfg(feature = "local_tests")]
     async fn create_plain_item() {
-        let service = Service::new(Algorithm::Plain).await.unwrap();
+        let service = Service::plain().await.unwrap();
         create_item(service, false).await;
     }
 
     #[async_std::test]
     #[cfg(feature = "local_tests")]
     async fn create_encrypted_item() {
-        let service = Service::new(Algorithm::Encrypted).await.unwrap();
+        let service = Service::encrypted().await.unwrap();
         create_item(service, true).await;
     }
 }

--- a/client/src/dbus/mod.rs
+++ b/client/src/dbus/mod.rs
@@ -2,10 +2,10 @@
 //!
 //! That is usually done with
 //! ```no_run
-//! use oo7::dbus::{Algorithm, Service};
+//! use oo7::dbus::Service;
 //!
 //! # async fn run() -> oo7::Result<()> {
-//! let service = Service::new(Algorithm::Plain).await?;
+//! let service = Service::new().await?;
 //!
 //! let mut attributes = std::collections::HashMap::new();
 //! attributes.insert("type", "password");
@@ -55,7 +55,7 @@ pub mod api;
 mod api;
 
 mod algorithm;
-pub use algorithm::Algorithm;
+pub(crate) use algorithm::Algorithm;
 mod item;
 pub use item::Item;
 mod error;

--- a/client/src/keyring.rs
+++ b/client/src/keyring.rs
@@ -7,7 +7,7 @@ use tokio::sync::RwLock;
 use zeroize::Zeroizing;
 
 use crate::{
-    dbus::{self, Algorithm, DEFAULT_COLLECTION},
+    dbus::{self, DEFAULT_COLLECTION},
     portal, Result,
 };
 
@@ -52,13 +52,7 @@ impl Keyring {
                 "Application is not sandboxed, falling back to the Sercret Service backend"
             );
         }
-        let service = match dbus::Service::new(Algorithm::Encrypted).await {
-            Ok(service) => Ok(service),
-            Err(dbus::Error::Zbus(zbus::Error::MethodError(_, _, _))) => {
-                dbus::Service::new(Algorithm::Plain).await
-            }
-            Err(e) => Err(e),
-        }?;
+        let service = dbus::Service::new().await?;
         let collection = match service.default_collection().await {
             Ok(c) => Ok(c),
             Err(dbus::Error::NotFound(_)) => {

--- a/client/src/migration.rs
+++ b/client/src/migration.rs
@@ -1,10 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{
-    dbus::{self, Algorithm, Service},
-    portal::Keyring,
-    Result,
-};
+use crate::{dbus::Service, portal::Keyring, Result};
 
 /// Helper to migrate your secrets from the host Secret Service
 /// to the sandboxed file backend.
@@ -12,13 +8,7 @@ use crate::{
 /// If the migration is successful, the items are removed from the host
 /// Secret Service.
 pub async fn migrate(attributes: Vec<HashMap<&str, &str>>, replace: bool) -> Result<()> {
-    let service = match Service::new(Algorithm::Encrypted).await {
-        Ok(service) => Ok(service),
-        Err(dbus::Error::Zbus(zbus::Error::MethodError(_, _, _))) => {
-            dbus::Service::new(Algorithm::Plain).await
-        }
-        Err(e) => Err(e),
-    }?;
+    let service = Service::new().await?;
     let file_backend = match Keyring::load_default().await {
         Ok(portal) => Ok(portal),
         Err(crate::portal::Error::PortalNotAvailable) => {


### PR DESCRIPTION
We have that use case inside the client library but also on the CI/portal sides