### PR TITLE
client/dbus: make Algorithm enum public under unstable feature

### DIFF
--- a/client/src/dbus/mod.rs
+++ b/client/src/dbus/mod.rs
@@ -55,7 +55,11 @@ pub mod api;
 mod api;
 
 mod algorithm;
+#[cfg(not(feature = "unstable"))]
 pub(crate) use algorithm::Algorithm;
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+pub use algorithm::Algorithm;
 mod item;
 pub use item::Item;
 mod error;


### PR DESCRIPTION
We need this change for server side implementation.
See: https://github.com/bilelmoussaoui/oo7/pull/56#discussion_r1482719151