### PR TITLE
ci/docs: Use latest actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,18 @@
-name: github pages
+name: docs
 
 on:
   push:
     branches:
-      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
 
 jobs:
-  build-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -23,8 +29,24 @@ jobs:
           command: doc
           args: --package oo7 --features "async-std, unstable" --no-deps
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Fix permissions
+        run: |
+          chmod -c -R +rX "target/doc/" | while read line; do
+            echo "::warning title=Invalid file permissions automatically fixed::$line"
+          done
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./target/doc/
+          path: ./target/doc/
+
+  deploy:
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: docs
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Avoids going through the gh-pages branch, reducing the repo size