### PR TITLE
portal: Add rekeying support for oo7::portal::Keyring

### DIFF
--- a/client/src/portal/api/mod.rs
+++ b/client/src/portal/api/mod.rs
@@ -252,6 +252,16 @@ impl Keyring {
             self.iteration_count.try_into().unwrap(),
         )
     }
+
+    // Reset Keyring content
+    pub(crate) fn reset(&mut self) {
+        let salt = rand::thread_rng().gen::<[u8; DEFAULT_SALT_SIZE]>().to_vec();
+        self.salt_size = salt.len() as u32;
+        self.salt = salt;
+        self.iteration_count = DEFAULT_ITERATION_COUNT;
+        self.usage_count = 0;
+        self.items = Vec::new();
+    }
 }
 
 impl TryFrom<&[u8]> for Keyring {

--- a/client/src/portal/mod.rs
+++ b/client/src/portal/mod.rs
@@ -425,6 +425,11 @@ impl Keyring {
         // Unset the old key
         *key_lock = None;
         drop(key_lock);
+
+        // Reset Keyring content before setting the new key
+        let mut keyring = self.keyring.write().await;
+        keyring.reset();
+        drop(keyring);
         let key = self.derive_key().await;
 
         let mut keyring = self.keyring.write().await;

--- a/client/src/portal/mod.rs
+++ b/client/src/portal/mod.rs
@@ -410,7 +410,6 @@ impl Keyring {
 
         let keyring = self.keyring.read().await;
         let key = self.derive_key().await;
-
         let mut items = Vec::with_capacity(keyring.items.len());
         for item in &keyring.items {
             items.push(item.clone().decrypt(&key)?);
@@ -430,10 +429,11 @@ impl Keyring {
         let mut keyring = self.keyring.write().await;
         keyring.reset();
         drop(keyring);
+
+        // Set new key
         let key = self.derive_key().await;
 
         let mut keyring = self.keyring.write().await;
-
         for item in items {
             let encrypted_item = item.encrypt(&key)?;
             keyring.items.push(encrypted_item);


### PR DESCRIPTION
This change adds `change_secret()` to `oo7::portal::Keyring` API.
`change_secret()` change/update the secret associated with a keyring.
Note: we need this change for the sever side implementation.

Fixes: #47 