### PR TITLE
ci: Replace actions-rs actions and add clippy checks for more client features

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,5 +68,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - name: Clippy
+      - name: Clippy workspace (default features)
         run: cargo clippy -- -D warnings
+      - name: Clippy client (tracing / async-std / native crypto)
+        run: cargo clippy -p oo7 --no-default-features --features tracing,async-std,native_crypto -- -D warnings
+      - name: Clippy client (tracing / tokio / OpenSSL)
+        run: cargo clippy -p oo7 --no-default-features --features tracing,tokio,openssl_crypto -- -D warnings

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,26 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
+        run: cargo check
 
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+      - uses: dtolnay/rust-toolchain@stable
       - name: Build client (async-std / native)
         run: |
           cargo build --manifest-path ./client/Cargo.toml --no-default-features --features async-std --features native_crypto
@@ -64,31 +54,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - run: rustup component add rustfmt
+          components: rustfmt
       - name: Rust Format
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@stable
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
+          components: clippy
       - name: Clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,18 +16,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
-      - uses: actions-rs/cargo@v1
-        env:
+      - uses: dtolnay/rust-toolchain@nightly
+      - env:
           RUSTFLAGS: --cfg docsrs
           RUSTDOCFLAGS: --cfg docsrs
-        with:
-          command: doc
-          args: --package oo7 --features "async-std, unstable" --no-deps
+        run: cargo doc --package oo7 --features "async-std, unstable" --no-deps
 
       - name: Fix permissions
         run: |

--- a/client/src/crypto/openssl.rs
+++ b/client/src/crypto/openssl.rs
@@ -157,7 +157,7 @@ pub(crate) fn verify_mac(data: impl AsRef<[u8]>, key: &Key, expected: impl AsRef
 
 pub(crate) fn verify_checksum_md5(digest: impl AsRef<[u8]>, content: impl AsRef<[u8]>) -> bool {
     memcmp::eq(
-        &*hash(MessageDigest::md5(), content.as_ref()).unwrap(),
+        &hash(MessageDigest::md5(), content.as_ref()).unwrap(),
         digest.as_ref(),
     )
 }
@@ -201,7 +201,7 @@ pub(crate) fn legacy_derive_key_and_iv(
         let mut digest = hasher.finish().unwrap();
 
         for _ in 1..iteration_count {
-            hasher.update(&*digest).unwrap();
+            hasher.update(&digest).unwrap();
             digest = hasher.finish().unwrap();
         }
 
@@ -213,7 +213,7 @@ pub(crate) fn legacy_derive_key_and_iv(
             break;
         }
 
-        hasher.update(&*digest).unwrap();
+        hasher.update(&digest).unwrap();
     }
 
     let iv = buffer.split_off(cipher.key_len());


### PR DESCRIPTION
Replace actions-rs actions because the [whole organization](https://github.com/actions-rs) was archived.

Add clippy checks for more client features to avoid issues like the one in #85 from making it to a release.

Needs #85 to pass CI.