### PR TITLE
portal: Mark test with `test` attribute

### DIFF
--- a/client/src/portal/api/legacy_keyring.rs
+++ b/client/src/portal/api/legacy_keyring.rs
@@ -240,6 +240,7 @@ mod tests {
 
     use super::*;
 
+    #[test]
     fn legacy_decrypt() -> Result<(), Error> {
         let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("fixtures")


### PR DESCRIPTION
This looks like a test, so I assumed it's just lacking the attribute. That made my IDE complain that the function was unused.