### PR TITLE
client: expose SecretInner

### DIFF
--- a/client/src/dbus/api/mod.rs
+++ b/client/src/dbus/api/mod.rs
@@ -27,5 +27,8 @@ pub(crate) use properties::Properties;
 #[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
 pub use properties::Properties;
 pub use secret::Secret;
+#[cfg(feature = "unstable")]
+#[cfg_attr(docsrs, doc(cfg(feature = "unstable")))]
+pub use secret::SecretInner;
 pub use service::Service;
 pub use session::Session;

--- a/client/src/dbus/api/secret.rs
+++ b/client/src/dbus/api/secret.rs
@@ -9,7 +9,7 @@ use crate::{crypto, dbus::Error, Key};
 
 #[derive(Debug, Serialize, Deserialize, Type)]
 #[zvariant(signature = "(oayays)")]
-pub(crate) struct SecretInner(pub OwnedObjectPath, pub Vec<u8>, pub Vec<u8>, pub String);
+pub struct SecretInner(pub OwnedObjectPath, pub Vec<u8>, pub Vec<u8>, pub String);
 
 #[derive(Debug, Type, Zeroize, ZeroizeOnDrop)]
 #[zvariant(signature = "(oayays)")]


### PR DESCRIPTION
This change exposes `SecretInner` under unstable feature.
We need this change for the server side implementation.