### PR TITLE
client/item: Replace existing item in `Item::set_attributes`

### DIFF
--- a/client/src/portal/api/mod.rs
+++ b/client/src/portal/api/mod.rs
@@ -198,6 +198,14 @@ impl Keyring {
             .transpose()
     }
 
+    pub fn lookup_item_index(&self, attributes: &impl AsAttributes, key: &Key) -> Option<usize> {
+        let hashed_search = attributes.hash(key);
+
+        self.items
+            .iter()
+            .position(|e| hashed_search.iter().all(|(k, v)| e.has_attribute(k, v)))
+    }
+
     pub fn remove_items(&mut self, attributes: &impl AsAttributes, key: &Key) -> Result<(), Error> {
         let hashed_search = attributes.hash(key);
 

--- a/client/src/portal/mod.rs
+++ b/client/src/portal/mod.rs
@@ -253,6 +253,14 @@ impl Keyring {
         keyring.lookup_item(attributes, &key)
     }
 
+    /// Find the index in the list of items of the first item matching the
+    /// attributes.
+    pub async fn lookup_item_index(&self, attributes: &impl AsAttributes) -> Option<usize> {
+        let key = self.derive_key().await;
+        let keyring = self.keyring.read().await;
+        keyring.lookup_item_index(attributes, &key)
+    }
+
     /// Delete an item.
     pub async fn delete(&self, attributes: &impl AsAttributes) -> Result<(), Error> {
         {


### PR DESCRIPTION
Instead of creating a new one because the attributes have changed.

Fixes #97.