### PR TITLE
portal: Add meson support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ exclude = ["org.freedesktop.Secrets.xml"]
 
 [workspace.dependencies]
 endi = "1.1"
+clap = { version = "4.4.6", features = [ "cargo", "derive" ] }
 futures-channel = "0.3"
 futures-lite = "2.1"
 futures-util = "0.3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 
 [dependencies]
 chrono = { version = "0.4.31", default-features = false, features = ["alloc", "clock"] }
-clap = { version = "4.4.6", features = [ "cargo", "derive" ] }
+clap.workspace = true
 oo7.workspace = true
 rpassword = "7.2.0"
 tokio = { workspace = true, features = [ "macros", "rt-multi-thread" ] }

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -21,5 +21,5 @@ serde.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "macros", "rt-multi-thread"] }
 tracing = "0.1"
 tracing-subscriber.workspace = true
-zbus.workspace = true
+zbus = { workspace = true, features = ["tokio"] }
 zeroize.workspace = true

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -12,6 +12,7 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+clap.workspace = true
 futures-channel.workspace = true
 futures-util.workspace = true
 oo7.workspace = true

--- a/portal/data/meson.build
+++ b/portal/data/meson.build
@@ -1,0 +1,27 @@
+configure_file(
+  input: 'oo7-portal.desktop.in',
+  output: 'oo7-portal.desktop',
+  configuration: libexecdir_conf,
+  install_dir: datadir / 'applications',
+)
+
+install_data(
+  'oo7-portal.portal',
+  install_dir: portal_dir,
+)
+
+if systemduserunitdir != ''
+  configure_file(
+    input: 'oo7-portal.service.in',
+    output: 'oo7-portal.service',
+    configuration: libexecdir_conf,
+    install_dir: systemduserunitdir,
+  )
+endif
+
+configure_file(
+  input: 'org.freedesktop.impl.portal.desktop.oo7.service.in',
+  output: 'org.freedesktop.impl.portal.desktop.oo7.service',
+  configuration: libexecdir_conf,
+  install_dir: dbus_service_dir,
+)

--- a/portal/data/oo7-portal.desktop.in
+++ b/portal/data/oo7-portal.desktop.in
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=Secret Portal
+# TRANSLATORS: Don't translate this text (this is icon name)
+Icon=applications-system-symbolic
+Exec=@libexecdir@/oo7-portal
+NoDisplay=true

--- a/portal/data/oo7-portal.portal
+++ b/portal/data/oo7-portal.portal
@@ -1,4 +1,4 @@
 [portal]
 DBusName=org.freedesktop.impl.portal.desktop.oo7
-Interfaces=org.freedesktop.impl.portal.Secret
+Interfaces=org.freedesktop.impl.portal.Secret;
 UseIn=gnome

--- a/portal/data/oo7-portal.service
+++ b/portal/data/oo7-portal.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.freedesktop.impl.portal.Secret
-Exec=@bindir@/oo7-portal

--- a/portal/data/oo7-portal.service.in
+++ b/portal/data/oo7-portal.service.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Secret portal service (oo7 implementation)
+After=graphical-session.target
+Requisite=graphical-session.target
+PartOf=graphical-session.target
+
+[Service]
+Type=dbus
+BusName=org.freedesktop.impl.portal.desktop.oo7
+ExecStart=@libexecdir@/oo7-portal

--- a/portal/data/org.freedesktop.impl.portal.desktop.oo7.service.in
+++ b/portal/data/org.freedesktop.impl.portal.desktop.oo7.service.in
@@ -1,0 +1,4 @@
+[D-BUS Service]
+Name=org.freedesktop.impl.portal.desktop.oo7
+Exec=@libexecdir@/oo7-portal
+SystemdService=org.freedesktop.impl.portal.desktop.oo7.service

--- a/portal/meson.build
+++ b/portal/meson.build
@@ -1,0 +1,40 @@
+project(
+  'oo7-portal',
+  'rust',
+  version: '0.1.0',
+  meson_version: '>= 0.59.0',
+)
+
+is_devel = get_option('profile') == 'development'
+
+prefix = get_option('prefix')
+datadir = get_option('datadir')
+dbus_service_dir = get_option('dbus_service_dir')
+libexecdir = get_option('libexecdir')
+
+build_systemd_service = get_option('systemd')
+systemduserunitdir = get_option('systemduserunitdir')
+if systemduserunitdir == ''
+  systemd = dependency('systemd', version: '>= 242', required: build_systemd_service)
+  if build_systemd_service.allowed() and systemd.found()
+    systemduserunitdir = systemd.get_variable(
+      pkgconfig: 'systemduserunitdir',
+      pkgconfig_define: ['prefix', prefix]
+    )
+  endif
+endif
+
+portal_dir = datadir / 'xdg-desktop-portal' / 'portals'
+
+libexecdir_conf = configuration_data()
+libexecdir_conf.set('libexecdir', prefix / libexecdir)
+
+summary({
+  'prefix': prefix,
+  'datadir': datadir,
+  'libexecdir': libexecdir,
+  'dbus_service_dir': dbus_service_dir,
+})
+
+subdir('data')
+subdir('src')

--- a/portal/meson_options.txt
+++ b/portal/meson_options.txt
@@ -1,0 +1,26 @@
+option('dbus_service_dir',
+  type: 'string',
+  description: 'Directory for D-Bus service files'
+)
+
+option('systemd',
+  type: 'feature',
+  value: 'auto',
+  description: 'Enable systemd support'
+)
+
+option('systemduserunitdir',
+  type: 'string',
+  description: 'Directory for systemd user service files'
+)
+
+option (
+  'profile',
+  type: 'combo',
+  choices: [
+    'default',
+    'development'
+  ],
+  value: 'default',
+  description: 'The build profile for Obfuscate. One of "default" or "development".'
+)

--- a/portal/src/main.rs
+++ b/portal/src/main.rs
@@ -129,6 +129,12 @@ async fn send_secret_to_app(app_id: &str, fd: zvariant::OwnedFd) -> Result<(), E
 async fn main() -> Result<(), zbus::Error> {
     tracing_subscriber::fmt::init();
 
+    tracing::info!(
+        "Initializing {} {}",
+        env!("CARGO_BIN_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
+
     let backend = Secret;
     let cnx = zbus::ConnectionBuilder::session()?
         .serve_at(oo7::portal::SecretProxy::PATH.unwrap(), backend)?

--- a/portal/src/meson.build
+++ b/portal/src/meson.build
@@ -1,0 +1,28 @@
+cargo = find_program('cargo')
+
+cargo_options = []
+cargo_options += [ '--target-dir', meson.project_build_root() / 'src' ]
+if is_devel
+  rust_target = 'debug'
+  message('Building in debug mode')
+else
+  cargo_options += [ '--release' ]
+  rust_target = 'release'
+  message('Building in release mode')
+endif
+
+cargo_build = custom_target(
+  'cargo-build',
+  build_by_default: true,
+  build_always_stale: true,
+  output: meson.project_name(),
+  console: true,
+  install: true,
+  install_dir: libexecdir,
+  command: [
+    cargo, 'build',
+    cargo_options,
+    '&&',
+    'cp', 'src' / rust_target / meson.project_name(), '@OUTPUT@',
+  ]
+)


### PR DESCRIPTION
# Test on Silverblue

Temporarily disable selinux

    setenforce 0

Create /run/extensions

    mkdir /run/extensions

Have a preferences file `~/.config/xdg-desktop-portal/gnome-portals.conf` with contents

```
[preferred]
default=gnome;gtk;
org.freedesktop.impl.portal.Secret=oo7-portal;
```

and restart xdg-desktop-portal

```
systemctl --user restart xdg-desktop-portal
```

From oo7/portal run in a toolbox:

    meson --prefix=/usr _build -Dprofile=development
    ninja -C _build && DESTDIR=oo7-extension meson install -C _build

From outside the sandbox:

```
cp -r _build/oo7-extension /run/extensions/ && systemd-sysext refresh --force
```

One can get more debug output by replacing services for xdp and oo7-portals:
```
/usr/libexec/xdg-desktop-portal -r -v
```

```
RUST_LOG=oo7_portal=debug RUST_BACKTRACE=full /usr/libexec/oo7-portal
```