### PR TITLE
portal: Replace ring with getrandom

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1032,8 +1032,8 @@ dependencies = [
  "clap",
  "futures-channel",
  "futures-util",
+ "getrandom",
  "oo7",
- "ring",
  "serde",
  "tokio",
  "tracing",
@@ -1220,21 +1220,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
-]
-
-[[package]]
-name = "ring"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
-dependencies = [
- "cc",
- "cfg-if",
- "getrandom",
- "libc",
- "spin",
- "untrusted",
- "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1556,12 +1541,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "untrusted"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"

--- a/deny.toml
+++ b/deny.toml
@@ -13,9 +13,7 @@ ignore = []
 allow = [
   "MIT",
   "Apache-2.0", # rpassword by cli only
-  "ISC", # used by untrusted -> ring by portal only
   "BSD-3-Clause", # used by subtle -> digest
-  "OpenSSL", # used by ring by portal only
   "Unicode-DFS-2016", # used by unicode-ident -> proc-macro2
 ]
 

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -16,7 +16,7 @@ clap.workspace = true
 futures-channel.workspace = true
 futures-util.workspace = true
 oo7.workspace = true
-ring = "0.17.5"
+getrandom = "0.2"
 serde.workspace = true
 tokio = { workspace = true, features = ["io-util", "net", "macros", "rt-multi-thread"] }
 tracing = "0.1"

--- a/portal/src/error.rs
+++ b/portal/src/error.rs
@@ -26,8 +26,8 @@ impl From<std::io::Error> for Error {
     }
 }
 
-impl From<ring::error::Unspecified> for Error {
-    fn from(err: ring::error::Unspecified) -> Self {
+impl From<getrandom::Error> for Error {
+    fn from(err: getrandom::Error) -> Self {
         Self::Owned(err.to_string())
     }
 }

--- a/portal/src/main.rs
+++ b/portal/src/main.rs
@@ -6,7 +6,6 @@ use std::{collections::HashMap, future::pending, os::unix::net::UnixStream};
 use clap::Parser;
 use futures_util::FutureExt;
 use oo7::dbus::Service;
-use ring::rand::SecureRandom;
 use tokio::io::AsyncWriteExt;
 use zbus::{
     zvariant::{self, OwnedObjectPath},
@@ -81,8 +80,8 @@ impl Secret {
 
 fn generate_secret() -> Result<zeroize::Zeroizing<Vec<u8>>, Error> {
     let mut secret = [0; PORTAL_SECRET_SIZE];
-    let rand = ring::rand::SystemRandom::new();
-    rand.fill(&mut secret)?;
+    // Equivalent of `ring::rand::SecureRandom`
+    getrandom::getrandom(&mut secret)?;
     Ok(zeroize::Zeroizing::new(secret.to_vec()))
 }
 


### PR DESCRIPTION
Which what ends up being used by ring::rand::SecureRandom Helps get rid of some licenses & two dependencies