### PR TITLE
cli: Use time::format_description::parse_borrowed

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -299,9 +299,10 @@ async fn print_item<'a>(
             }
         }
 
-        let format =
-            time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
-                .unwrap();
+        let format = time::format_description::parse_borrowed::<2>(
+            "[year]-[month]-[day] [hour]:[minute]:[second]",
+        )
+        .unwrap();
 
         writeln!(
             &mut result,


### PR DESCRIPTION
Instead of parse. See its documentation
https://docs.rs/time/latest/time/format_description/fn.parse.html where it says that it should be used instead. The difference between v1 and v2 is mostly about escaping characters we don't use here.