### PR TITLE
 portal: Keyring::load() verify secret before returning a Keyring

### DIFF
--- a/client/src/portal/error.rs
+++ b/client/src/portal/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     Utf8(std::str::Utf8Error),
     /// Mismatch of algorithms used in legacy keyring file.
     AlgorithmMismatch(u8),
+    /// Keyring secret mismatch
+    InvalidSecret,
 }
 
 impl From<zvariant::Error> for Error {
@@ -105,6 +107,7 @@ impl std::fmt::Display for Error {
             Error::InvalidItemIndex(index) => write!(f, "The addressed item index {index} does not exist"),
             Error::Utf8(e) => write!(f, "UTF-8 encoding error {e}"),
             Error::AlgorithmMismatch(e) => write!(f, "Unknown algorithm {e}"),
+            Error::InvalidSecret => write!(f, "Keyring secret does not match the expected value"),
         }
     }
 }


### PR DESCRIPTION
Adds `verify_secret()`.

With this change, calls to `oo7::portal::Keyring::load()`, and
`oo7::portal::Keyring::open()` will fail when used with a
wrong secret/password.

Also adds `oo7::portal::Keyring::verify_secret()` API and introduces `InvalidSecret` error.