### PR TITLE
server: Store connection to the session bus in Service

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -14,7 +14,8 @@ async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
     tracing::info!("Starting {}", BINARY_NAME);
 
-    Service::run().await?;
+    let service = Service::new().await?;
+    service.run().await?;
 
     std::future::pending::<()>().await;
 


### PR DESCRIPTION
This is to avoid the connection to the session bus being dropped.

A bit of background: I've been trying to get a response to `busctl --user tree org.freedesktop.secrets` command from oo7-daemon (after killing gnome-keyring-daemon). As soon as I issue the command, `gnome-keyring-daemon` starts running again and becomes the secret service provider. I'm not sure why this happens. But this change fixes this issue and the object tree is now nicely generated.

```
└─ /org
  └─ /org/freedesktop
    └─ /org/freedesktop/secrets
```