### PR TITLE
server: Dispatch temporary session collection to the object tree

### DIFF
--- a/server/src/collection.rs
+++ b/server/src/collection.rs
@@ -1,15 +1,34 @@
 // org.freedesktop.Secret.Collection
 
-use std::collections::HashMap;
+use std::{
+    collections::HashMap,
+    sync::{atomic::AtomicBool, Arc},
+    time::{Duration, SystemTime},
+};
 
 use oo7::dbus::api::{Properties, SecretInner};
+use tokio::sync::{Mutex, RwLock};
 use zbus::{interface, zvariant};
 use zvariant::{ObjectPath, OwnedObjectPath};
 
 use super::Result;
+use crate::{item, service_manager::ServiceManager};
 
 #[derive(Debug)]
-pub struct Collection {}
+#[allow(unused)]
+pub struct Collection {
+    // Properties
+    items: Mutex<Vec<item::Item>>,
+    label: Mutex<String>,
+    locked: AtomicBool,
+    created: Duration,
+    modified: Mutex<Duration>,
+    // Other attributes
+    alias: Mutex<String>,
+    manager: Arc<Mutex<ServiceManager>>,
+    n_items: RwLock<i32>,
+    path: OwnedObjectPath,
+}
 
 #[interface(name = "org.freedesktop.Secret.Collection")]
 impl Collection {
@@ -31,5 +50,33 @@ impl Collection {
         _replace: bool,
     ) -> Result<(OwnedObjectPath, ObjectPath)> {
         todo!()
+    }
+}
+
+impl Collection {
+    pub fn new(label: &str, alias: &str, manager: Arc<Mutex<ServiceManager>>) -> Self {
+        let created = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap();
+
+        Self {
+            items: Default::default(),
+            label: Mutex::new(label.to_owned()),
+            locked: AtomicBool::new(true),
+            modified: Mutex::new(created),
+            alias: Mutex::new(alias.to_owned()),
+            n_items: RwLock::new(0),
+            path: OwnedObjectPath::try_from(format!(
+                "/org/freedesktop/secrets/collection/{}",
+                label
+            ))
+            .unwrap(),
+            created,
+            manager,
+        }
+    }
+
+    pub fn path(&self) -> &OwnedObjectPath {
+        &self.path
     }
 }


### PR DESCRIPTION
This change creates and dispatches the temporary collection called session.
This collection is never stored to disk, but forgotten when the session ends.

`org.freedesktop.secrets` object tree:

```
└─ /org
  └─ /org/freedesktop
    └─ /org/freedesktop/secrets
      └─ /org/freedesktop/secrets/collection
        └─ /org/freedesktop/secrets/collection/session
```