### PR TITLE
server: Load and dispatch login/default collection/keyring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,7 +1086,9 @@ dependencies = [
 name = "oo7-daemon"
 version = "0.3.0"
 dependencies = [
+ "clap",
  "oo7",
+ "rpassword",
  "serde",
  "tokio",
  "tracing",

--- a/client/src/portal/secret.rs
+++ b/client/src/portal/secret.rs
@@ -1,3 +1,4 @@
+use rand::Rng;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 /// Secret used to unlock the keyring.
@@ -15,5 +16,11 @@ impl std::ops::Deref for Secret {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Secret {
+    pub fn random() -> Self {
+        Self(rand::thread_rng().gen::<[u8; 8]>().to_vec())
     }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,7 +9,9 @@ rust-version.workspace = true
 version.workspace = true
 
 [dependencies]
+clap.workspace = true
 oo7 = { workspace = true, features = ["unstable"] }
+rpassword = "7.3"
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }
 tracing = "0.1"

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -1,0 +1,42 @@
+use std::fmt;
+
+#[derive(Debug)]
+pub enum Error {
+    // File backend error
+    Portal(oo7::portal::Error),
+    // Zbus error
+    Zbus(zbus::Error),
+    // IO error
+    IO(std::io::Error),
+    // Empty password error
+    EmptyPassword,
+}
+
+impl From<zbus::Error> for Error {
+    fn from(err: zbus::Error) -> Self {
+        Self::Zbus(err)
+    }
+}
+
+impl From<oo7::portal::Error> for Error {
+    fn from(err: oo7::portal::Error) -> Self {
+        Self::Portal(err)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(err: std::io::Error) -> Self {
+        Self::IO(err)
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Portal(err) => write!(f, "Portal error {err}"),
+            Self::Zbus(err) => write!(f, "Zbus error {err}"),
+            Self::IO(err) => write!(f, "IO error {err}"),
+            Self::EmptyPassword => write!(f, "Login password can't be empty"),
+        }
+    }
+}

--- a/server/src/item.rs
+++ b/server/src/item.rs
@@ -1,9 +1,7 @@
 // org.freedesktop.Secret.Item
 
-use oo7::dbus::api::SecretInner;
+use oo7::dbus::{api::SecretInner, ServiceError};
 use zbus::zvariant::ObjectPath;
-
-use super::Result;
 
 #[derive(Debug)]
 pub struct Item {}
@@ -11,16 +9,16 @@ pub struct Item {}
 #[zbus::interface(name = "org.freedesktop.Secret.Item")]
 impl Item {
     #[zbus(out_args("prompt"))]
-    pub async fn delete(&self) -> Result<ObjectPath> {
+    pub async fn delete(&self) -> Result<ObjectPath, ServiceError> {
         todo!()
     }
 
     #[zbus(out_args("secret"))]
-    pub async fn get_secret(&self, _session: ObjectPath<'_>) -> Result<SecretInner> {
+    pub async fn get_secret(&self, _session: ObjectPath<'_>) -> Result<SecretInner, ServiceError> {
         todo!()
     }
 
-    pub async fn set_secret(&self, _secret: SecretInner) -> Result<()> {
+    pub async fn set_secret(&self, _secret: SecretInner) -> Result<(), ServiceError> {
         todo!()
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,20 +1,49 @@
 mod collection;
+mod error;
 mod item;
 mod prompt;
 mod service;
 mod service_manager;
 mod session;
 
-use service::{Result, Service};
+use clap::Parser;
+use oo7::portal::Secret;
+use service::Service;
+
+use crate::error::Error;
 
 const BINARY_NAME: &str = env!("CARGO_BIN_NAME");
 
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Args {
+    #[arg(
+        short = 'l',
+        long,
+        default_value_t = false,
+        help = "Read a password from stdin, and use it to unlock the login keyring."
+    )]
+    login: bool,
+}
+
 #[tokio::main]
-async fn main() -> Result<()> {
+async fn main() -> Result<(), Error> {
     tracing_subscriber::fmt::init();
+    let args = Args::parse();
+    let mut secret: Option<Secret> = None;
+
+    if args.login {
+        let password = rpassword::prompt_password("Enter the login password: ")?;
+        if password.is_empty() {
+            tracing::error!("Login password can't be empty.");
+            return Err(Error::EmptyPassword);
+        }
+        secret = Some(Secret::from(password.into_bytes()));
+    }
+
     tracing::info!("Starting {}", BINARY_NAME);
 
-    Service::run().await?;
+    Service::run(secret).await?;
 
     std::future::pending::<()>().await;
 

--- a/server/src/prompt.rs
+++ b/server/src/prompt.rs
@@ -1,19 +1,18 @@
 // org.freedesktop.Secret.Prompt
 
+use oo7::dbus::ServiceError;
 use zbus::interface;
-
-use super::Result;
 
 #[derive(Debug)]
 pub struct Prompt {}
 
 #[interface(name = "org.freedesktop.Secret.Prompt")]
 impl Prompt {
-    pub async fn prompt(&self, _window_id: &str) -> Result<()> {
+    pub async fn prompt(&self, _window_id: &str) -> Result<(), ServiceError> {
         todo!()
     }
 
-    pub async fn dismiss(&self) -> Result<()> {
+    pub async fn dismiss(&self) -> Result<(), ServiceError> {
         todo!()
     }
 }

--- a/server/src/session.rs
+++ b/server/src/session.rs
@@ -2,11 +2,10 @@
 
 use std::sync::Arc;
 
-use oo7::Key;
+use oo7::{dbus::ServiceError, Key};
 use tokio::sync::Mutex;
 use zbus::{interface, zvariant::OwnedObjectPath};
 
-use super::Result;
 use crate::service_manager::ServiceManager;
 
 #[derive(Debug, Clone)]
@@ -21,7 +20,7 @@ impl Session {
     pub async fn close(
         &self,
         #[zbus(object_server)] object_server: &zbus::ObjectServer,
-    ) -> Result<()> {
+    ) -> Result<(), ServiceError> {
         self.manager.lock().await.remove_session(&self.path);
         object_server.remove::<Self, _>(&self.path).await?;
 


### PR DESCRIPTION
Load temporary keyring when dispatching the session collection. Since the session collection is never stored to the disk, loading a temporary keyring is enough.
- And add Collection::new()
- Also store a Keyring in Collection struct.

This change loads and dispatches the login/default collection/keyring into the object tree. This change also adds,
- `--login` command line option to oo7-daemon.
- `-l, --login` option will read a password from stdin, and use it to unlock the login keyring.
- Note: currently -l option will only load the login keyring and not perform anything related to unlocking the keyring.
