### PR TITLE
server: Dispatch default collection items

### DIFF
--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     IO(std::io::Error),
     // Empty password error
     EmptyPassword,
+    // Invalid item error
+    InvalidItem(oo7::portal::InvalidItemError),
 }
 
 impl From<zbus::Error> for Error {
@@ -37,6 +39,7 @@ impl fmt::Display for Error {
             Self::Zbus(err) => write!(f, "Zbus error {err}"),
             Self::IO(err) => write!(f, "IO error {err}"),
             Self::EmptyPassword => write!(f, "Login password can't be empty"),
+            Self::InvalidItem(err) => write!(f, "Item cannot be decrypted {err}"),
         }
     }
 }

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -220,10 +220,12 @@ impl Service {
             let collection = Collection::new(
                 "login",
                 "default",
+                false,
                 Arc::clone(&service.manager),
                 Arc::new(Keyring::open("login", secret).await?),
             );
             collections.push(collection.path().clone());
+            collection.dispatch_items().await?;
             object_server
                 .at(collection.path().clone(), collection)
                 .await?;
@@ -232,6 +234,7 @@ impl Service {
         let collection = Collection::new(
             "session",
             "session",
+            false,
             Arc::clone(&service.manager),
             Arc::new(Keyring::temporary(Secret::random()).await?),
         );
@@ -239,8 +242,6 @@ impl Service {
         object_server
             .at(collection.path().clone(), collection)
             .await?;
-
-        drop(collections);
 
         Ok(())
     }

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -27,8 +27,6 @@ pub struct Service {
     collections: Arc<Mutex<Vec<OwnedObjectPath>>>,
     // Other attributes
     manager: Arc<Mutex<ServiceManager>>,
-    #[allow(unused)]
-    connection: zbus::Connection,
 }
 
 #[zbus::interface(name = "org.freedesktop.Secret.Service")]
@@ -206,8 +204,7 @@ impl Service {
         let object_server = connection.object_server();
         let service = Self {
             collections: Default::default(),
-            manager: Default::default(),
-            connection: connection.clone(),
+            manager: Arc::new(Mutex::new(ServiceManager::new(connection.clone()))),
         };
 
         object_server

--- a/server/src/service_manager.rs
+++ b/server/src/service_manager.rs
@@ -2,19 +2,19 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use zbus::{zvariant::OwnedObjectPath, Connection};
+use zbus::zvariant::OwnedObjectPath;
 
 use crate::session::Session;
 
 #[derive(Debug)]
 pub struct ServiceManager {
-    connection: Connection,
+    connection: zbus::Connection,
     // sessions mapped to their corresponding object path on the bus
     sessions: HashMap<OwnedObjectPath, Arc<Session>>,
 }
 
 impl ServiceManager {
-    pub fn new(connection: Connection) -> Self {
+    pub fn new(connection: zbus::Connection) -> Self {
         Self {
             sessions: Default::default(),
             connection,

--- a/server/src/service_manager.rs
+++ b/server/src/service_manager.rs
@@ -2,17 +2,29 @@
 
 use std::{collections::HashMap, sync::Arc};
 
-use zbus::zvariant::OwnedObjectPath;
+use zbus::{zvariant::OwnedObjectPath, Connection};
 
 use crate::session::Session;
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ServiceManager {
+    connection: Connection,
     // sessions mapped to their corresponding object path on the bus
     sessions: HashMap<OwnedObjectPath, Arc<Session>>,
 }
 
 impl ServiceManager {
+    pub fn new(connection: Connection) -> Self {
+        Self {
+            sessions: Default::default(),
+            connection,
+        }
+    }
+
+    pub fn object_server(&self) -> &zbus::ObjectServer {
+        self.connection.object_server()
+    }
+
     pub fn n_sessions(&self) -> usize {
         self.sessions.len()
     }


### PR DESCRIPTION
And, Collection::new() now takes an additional parameter: locked. Based on this the locked status of a collection is determined. When the daemon is executed with the -l option, default collection and its items will be in unlocked status.