### PR TITLE
Disable oo7 default-features in workspace.dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ clap = { version = "4.5", features = [ "cargo", "derive" ] }
 futures-channel = "0.3"
 futures-lite = "2.6"
 futures-util = "0.3"
-oo7 = { path = "client", version = "0.4", features = ["unstable", "tracing"]}
+oo7 = { path = "client", version = "0.4", default-features = false, features = ["unstable", "tracing"]}
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.43", default-features = false }
 tempfile = "3.17"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -16,6 +16,6 @@ version.workspace = true
 time = { version = "0.3", default-features = false, features = ["alloc", "formatting", "local-offset"] }
 clap.workspace = true
 hex = "0.4"
-oo7.workspace = true
+oo7 = { workspace = true, default-features = true }
 rpassword = "7.2.0"
 tokio = { workspace = true, features = [ "macros", "rt"] }

--- a/client/src/dbus/api/collection.rs
+++ b/client/src/dbus/api/collection.rs
@@ -106,10 +106,7 @@ impl<'a> Collection<'a> {
     }
 
     pub async fn set_label(&self, label: &str) -> Result<(), Error> {
-        self.inner()
-            .set_property("Label", label)
-            .await
-            .map_err::<zbus::fdo::Error, _>(From::from)?;
+        self.inner().set_property("Label", label).await?;
         Ok(())
     }
 
@@ -180,7 +177,7 @@ impl<'a> Collection<'a> {
         let cnx = self.inner().connection();
         let item_path = if let Some(prompt) = Prompt::new(cnx, prompt_path).await? {
             let response = prompt.receive_completed(window_id).await?;
-            OwnedObjectPath::try_from(response).map_err::<zbus::zvariant::Error, _>(From::from)?
+            OwnedObjectPath::try_from(response)?
         } else {
             item_path
         };

--- a/client/src/dbus/api/item.rs
+++ b/client/src/dbus/api/item.rs
@@ -74,10 +74,7 @@ impl<'a> Item<'a> {
     }
 
     pub async fn set_label(&self, label: &str) -> Result<(), Error> {
-        self.inner()
-            .set_property("Label", label)
-            .await
-            .map_err::<zbus::fdo::Error, _>(From::from)?;
+        self.inner().set_property("Label", label).await?;
         Ok(())
     }
 
@@ -101,8 +98,7 @@ impl<'a> Item<'a> {
     pub async fn set_attributes(&self, attributes: &impl AsAttributes) -> Result<(), Error> {
         self.inner()
             .set_property("Attributes", attributes.as_attributes())
-            .await
-            .map_err::<zbus::fdo::Error, _>(From::from)?;
+            .await?;
         Ok(())
     }
 

--- a/client/src/dbus/api/service.rs
+++ b/client/src/dbus/api/service.rs
@@ -127,14 +127,13 @@ impl<'a> Service<'a> {
             .body()
             .deserialize::<(OwnedObjectPath, OwnedObjectPath)>()?;
 
-        let collection_path = if let Some(prompt) =
-            Prompt::new(self.inner().connection(), prompt_path).await?
-        {
-            let response = prompt.receive_completed(window_id).await?;
-            OwnedObjectPath::try_from(response).map_err::<zbus::zvariant::Error, _>(From::from)?
-        } else {
-            collection_path
-        };
+        let collection_path =
+            if let Some(prompt) = Prompt::new(self.inner().connection(), prompt_path).await? {
+                let response = prompt.receive_completed(window_id).await?;
+                OwnedObjectPath::try_from(response)?
+            } else {
+                collection_path
+            };
         Collection::new(self.inner().connection(), collection_path).await
     }
 
@@ -174,8 +173,7 @@ impl<'a> Service<'a> {
 
         if let Some(prompt) = Prompt::new(cnx, prompt_path).await? {
             let response = prompt.receive_completed(window_id).await?;
-            let locked_paths = Vec::<OwnedObjectPath>::try_from(response)
-                .map_err::<zbus::zvariant::Error, _>(From::from)?;
+            let locked_paths = Vec::<OwnedObjectPath>::try_from(response)?;
             unlocked_item_paths.extend(locked_paths);
         };
         Ok(unlocked_item_paths)
@@ -197,8 +195,7 @@ impl<'a> Service<'a> {
 
         if let Some(prompt) = Prompt::new(cnx, prompt_path).await? {
             let response = prompt.receive_completed(window_id).await?;
-            let locked_paths = Vec::<OwnedObjectPath>::try_from(response)
-                .map_err::<zbus::zvariant::Error, _>(From::from)?;
+            let locked_paths = Vec::<OwnedObjectPath>::try_from(response)?;
             locked_item_paths.extend(locked_paths);
         };
 

--- a/portal/Cargo.toml
+++ b/portal/Cargo.toml
@@ -14,7 +14,7 @@ version.workspace = true
 [dependencies]
 ashpd = {workspace = true, features = ["backend", "tracing"]}
 clap.workspace = true
-oo7.workspace = true
+oo7 = { workspace = true, default-features = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing.workspace = true
 tracing-subscriber.workspace = true

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ version.workspace = true
 [dependencies]
 clap.workspace = true
 enumflags2 = "0.7"
-oo7 = { workspace = true, features = ["unstable"] }
+oo7 = { workspace = true, default-features = true }
 rpassword = "7.3"
 serde.workspace = true
 tokio = { workspace = true, features = ["full"] }


### PR DESCRIPTION
This is to stop oo7/native_crypto feature being enabled when using oo7/openssl_crypto on the server side (or the opposite).

This also resolves the following error when setting oo7 `default-features = false` in workspace members.
"`default-features` is ignored for oo7, since `default-features` was not specified for `workspace.dependencies.oo7`, this could become a hard error in the future".