### PR TITLE
daemon: Do not restrict caps on unit file

### DIFF
--- a/server/data/oo7-daemon.service.in
+++ b/server/data/oo7-daemon.service.in
@@ -9,10 +9,6 @@ Restart=on-failure
 TimeoutStartSec=30s
 TimeoutStopSec=30s
 
-# Only allow CAP_IPC_LOCK
-CapabilityBoundingSet=CAP_IPC_LOCK
-AmbientCapabilities=CAP_IPC_LOCK
-
 # Prevent privilege escalation (blocks suid, new caps, etc.)
 NoNewPrivileges=true
 


### PR DESCRIPTION
The unit file is a user unit file. This means that it will automatically fail (with code 218) when started with either the CapabilityBoundingSet or AmbientCapabilities properties. This can be tested by running any of:

```
systemd-run --pipe --wait --user --property CapabilityBoundingSet=CAP_IPC_LOCK echo 1
systemd-run --pipe --wait --user --property AmbientCapabilities=CAP_IPC_LOCK echo 1
```