### PR TITLE
server: Demote info! to debug!

### DIFF
--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -219,7 +219,7 @@ impl Service {
 
         for collection in collections.iter() {
             if collection.alias().await == name {
-                tracing::info!(
+                tracing::debug!(
                     "Collection: {} found for alias: {}.",
                     collection.path(),
                     name


### PR DESCRIPTION
This was a bit too spammy. Another option would be to keep a hashmap of already resolved collections to only print this once per alias, but it seems like too much work and a waste of memory.