### PR TITLE
client: Stop giving mac as Zeroizing

### DIFF
--- a/client/src/file/api/attribute_value.rs
+++ b/client/src/file/api/attribute_value.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use zbus::zvariant::Type;
-use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
+use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{Key, crypto};
 
@@ -9,8 +9,8 @@ use crate::{Key, crypto};
 pub struct AttributeValue(String);
 
 impl AttributeValue {
-    pub(crate) fn mac(&self, key: &Key) -> Result<Zeroizing<Vec<u8>>, crate::crypto::Error> {
-        Ok(Zeroizing::new(crypto::compute_mac(self.0.as_bytes(), key)?))
+    pub(crate) fn mac(&self, key: &Key) -> Result<Vec<u8>, crate::crypto::Error> {
+        crypto::compute_mac(self.0.as_bytes(), key)
     }
 }
 

--- a/client/src/file/item.rs
+++ b/client/src/file/item.rs
@@ -154,7 +154,7 @@ impl Item {
         let hashed_attributes = self
             .attributes
             .iter()
-            .filter_map(|(k, v)| Some((k.to_owned(), v.mac(key).ok()?.as_slice().into())))
+            .filter_map(|(k, v)| Some((k.to_owned(), v.mac(key).ok()?)))
             .collect();
 
         Ok(EncryptedItem {

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -63,10 +63,7 @@ pub trait AsAttributes {
     fn hash<'a>(
         &'a self,
         key: &Key,
-    ) -> Vec<(
-        &'a str,
-        std::result::Result<zeroize::Zeroizing<Vec<u8>>, crate::crypto::Error>,
-    )> {
+    ) -> Vec<(&'a str, std::result::Result<Vec<u8>, crate::crypto::Error>)> {
         self.as_attributes()
             .into_iter()
             .map(|(k, v)| (k, crate::file::AttributeValue::from(v).mac(key)))


### PR DESCRIPTION
A mac does not contain sensitive data (no more than a hash at least), it does not need zeroizing on drop.