### PR TITLE
Use zvariant::Value::try_into_owned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "5.9.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb4f9a464286d42851d18a605f7193b8febaf5b0919d71c6399b7b26e5b0aad"
+checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
 dependencies = [
  "async-broadcast",
  "async-executor",
@@ -2266,7 +2266,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uds_windows",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winnow",
  "zbus_macros",
  "zbus_names",
@@ -2275,9 +2275,9 @@ dependencies = [
 
 [[package]]
 name = "zbus_macros"
-version = "5.9.0"
+version = "5.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef9859f68ee0c4ee2e8cde84737c78e3f4c54f946f2a38645d0d4c7a95327659"
+checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2396,9 +2396,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "5.6.0"
+version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91b3680bb339216abd84714172b5138a4edac677e641ef17e1d8cb1b3ca6e6f"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
 dependencies = [
  "endi",
  "enumflags2",
@@ -2411,9 +2411,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.6.0"
+version = "5.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a8c68501be459a8dbfffbe5d792acdd23b4959940fc87785fb013b32edbc208"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,6 @@ tokio = { version = "1.47", default-features = false }
 tempfile = "3.21"
 tracing = "0.1"
 tracing-subscriber = "0.3"
-zbus = { version = "5.9", default-features = false }
+zbus = { version = "5.9.1", default-features = false }
 zbus_macros = {version = "5.5", features = ["gvariant"]}
 zeroize = { version = "1", features = ["zeroize_derive"] }

--- a/client/src/key.rs
+++ b/client/src/key.rs
@@ -66,7 +66,7 @@ impl From<Key> for zvariant::Value<'static> {
 
 impl From<Key> for zvariant::OwnedValue {
     fn from(key: Key) -> Self {
-        zvariant::Value::from(key).try_to_owned().unwrap()
+        zvariant::Value::from(key).try_into_owned().unwrap()
     }
 }
 

--- a/server/src/gnome/prompter.rs
+++ b/server/src/gnome/prompter.rs
@@ -346,7 +346,7 @@ impl PrompterCallback {
 
         let signal_emitter = self.service.signal_emitter(prompt_path)?;
         let result = zvariant::Value::new(prompt.objects())
-            .try_to_owned()
+            .try_into_owned()
             .unwrap();
 
         tokio::spawn(async move {
@@ -387,7 +387,7 @@ impl PrompterCallback {
         tokio::spawn(async move { prompter.stop_prompting(&path).await });
         let signal_emitter = self.service.signal_emitter(prompt_path)?;
         let result = zvariant::Value::new::<Vec<OwnedObjectPath>>(vec![])
-            .try_to_owned()
+            .try_into_owned()
             .unwrap();
 
         tokio::spawn(async move { Prompt::completed(&signal_emitter, true, result).await });

--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -98,7 +98,7 @@ impl Service {
 
         let service_key = public_key
             .map(OwnedValue::from)
-            .unwrap_or_else(|| Value::new::<Vec<u8>>(vec![]).try_to_owned().unwrap());
+            .unwrap_or_else(|| Value::new::<Vec<u8>>(vec![]).try_into_owned().unwrap());
 
         Ok((service_key, path))
     }


### PR DESCRIPTION
Like try_to_owned, but without unnecessary allocations. This method was introduced in zvariant 5.7:
https://github.com/dbus2/zbus/pull/1440/files.