### PR TITLE
server: Fix sessions are not closing when clients leave

### DIFF
--- a/server/src/service.rs
+++ b/server/src/service.rs
@@ -516,10 +516,9 @@ impl Service {
             .build();
         let mut stream = zbus::MessageStream::for_match_rule(rule, self.connection(), None).await?;
         while let Some(message) = stream.try_next().await? {
-            let Ok((_name, old_owner, new_owner)) =
-                message
-                    .body()
-                    .deserialize::<(String, OwnedUniqueName, OwnedUniqueName)>()
+            let Ok((_name, old_owner, new_owner)) = message
+                .body()
+                .deserialize::<(String, OwnedUniqueName, String)>()
             else {
                 continue;
             };


### PR DESCRIPTION
Call to message.body().deserialize() fails with
"Invalid unique name" error when trying to deserialize an empty string ("") as an OwnedUniqueName. Changing the type of new_owner to String fixes this issue.

This completes: #302