### PR TITLE
pam: meson: Add missing pam dependency

### DIFF
--- a/pam/meson.build
+++ b/pam/meson.build
@@ -10,6 +10,8 @@ is_devel = get_option('profile') == 'development'
 prefix = get_option('prefix')
 libdir = get_option('libdir')
 
+dependency('pam')
+
 # PAM modules directory
 pam_moduledir = get_option('pam_moduledir')
 if pam_moduledir == ''


### PR DESCRIPTION
Note that 

```
dnf install pam-devel
```
results in

```
$ pkg-config --list-all | grep pam
pam                            PAM - The primary Linux-PAM library. It is used by PAM modules and PAM-aware applications.
pam_misc                       pam_misc - Miscellaneous functions that make the job of writing PAM-aware applications easier.
pamc                           libpamc - The PAM client API library and binary prompt support. Rarely used.
```

so I am not 100% sure if this is the right one, but g-k-d has it.