### PR TITLE
Revert "ci: Add pam-devel as a dependency"

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -125,7 +125,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies
-        run: dnf install -y git meson gcc systemd pam-devel
+        run: dnf install -y git meson gcc systemd
       - name: Build (portal)
         working-directory: ./portal
         run: meson setup ./ _build --prefix /usr && ninja -C _build

--- a/pam/meson.build
+++ b/pam/meson.build
@@ -10,8 +10,6 @@ is_devel = get_option('profile') == 'development'
 prefix = get_option('prefix')
 libdir = get_option('libdir')
 
-dependency('pam')
-
 # PAM modules directory
 pam_moduledir = get_option('pam_moduledir')
 if pam_moduledir == ''


### PR DESCRIPTION
These were not truly needed to compile the module.

This reverts commit 4ccdb07d318dd6ace6dc0ae6b7bcc416f16f01b8. This reverts commit 2de4daaf8ea8c19aabf3435cc49b6a19e0b93c7d.