### PR TITLE
Add Ukrainian translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -1,2 +1,3 @@
 kk
 pt_BR
+uk

--- a/server/po/uk.po
+++ b/server/po/uk.po
@@ -1,0 +1,91 @@
+# Ukrainian translation for oo7.
+# Copyright (C) 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+#
+# Yuri Chornoivan <yurchor@ukr.net>,  2026.
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-14 17:27+0000\n"
+"PO-Revision-Date: 2026-03-14 21:09+0200\n"
+"Last-Translator: Yuri Chornoivan <yurchor@ukr.net>\n"
+"Language-Team: Ukrainian <trans-uk@lists.fedoraproject.org>\n"
+"Language: uk\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 3 : n%10==1 && n%100!=11 ? 0 : n"
+"%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"X-Generator: Lokalize 23.04.3\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "Змінити пароль до сховища ключів"
+
+#: ../src/gnome/prompter.rs:133
+#, rust-format
+msgid "Choose a new password for the “{}” keyring"
+msgstr "Виберіть новий пароль до сховища ключів «{}»"
+
+#: ../src/gnome/prompter.rs:136
+#, rust-format
+msgid ""
+"An application wants to change the password for the “{}” keyring. Choose the "
+"new password you want to use for it."
+msgstr ""
+"Програма має намір змінити пароль до сховища ключів «{}». Виберіть новий"
+" пароль, яким ви хочете користуватися для нього."
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "Наслідки цієї дії не можна буде скасувати"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "Продовжити"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
+#: ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "Скасувати"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "Розблокувати сховище ключів"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "Слід пройти розпізнавання"
+
+#: ../src/gnome/prompter.rs:162
+#, rust-format
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr ""
+"Програмах хоче отримати доступ до сховища ключів «{}», але сховище"
+" заблоковано"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "Розблокувати"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "Пароль до нового сховища ключів"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "Виберіть пароль до нового сховища ключів"
+
+#: ../src/gnome/prompter.rs:184
+#, rust-format
+msgid ""
+"An application wants to create a new keyring called “{}”. Choose the "
+"password you want to use for it."
+msgstr ""
+"Програма намагається створити сховище ключів із назвою «{}». Виберіть"
+" пароль, яким ви хочете скористатися для нього."
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "Створити"


### PR DESCRIPTION
Add translation in Ukrainian from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/36/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.