### PR TITLE
Add Chinese (China) translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -2,3 +2,4 @@ kk
 pt_BR
 sl
 uk
+zh_CN

--- a/server/po/zh_CN.po
+++ b/server/po/zh_CN.po
@@ -1,0 +1,84 @@
+# Chinese (China) translation for oo7.
+# Copyright (C) 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+# lumingzh <lumingzh@qq.com>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-14 21:43+0000\n"
+"PO-Revision-Date: 2026-03-15 11:16+0800\n"
+"Last-Translator: lumingzh <lumingzh@qq.com>\n"
+"Language-Team: Chinese (China) <i18n-zh@googlegroups.com>\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Gtranslator 49.0\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "更改密钥环密码"
+
+#: ../src/gnome/prompter.rs:133
+#, rust-format
+msgid "Choose a new password for the “{}” keyring"
+msgstr "选择用于“{}”密钥环的新密码"
+
+#: ../src/gnome/prompter.rs:136
+#, rust-format
+msgid ""
+"An application wants to change the password for the “{}” keyring. Choose the "
+"new password you want to use for it."
+msgstr "有应用程序想要更改“{}”密钥环的密码。请选择您要对其使用的新密码。"
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "此操作无法恢复"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "继续"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
+#: ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "取消"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "解锁密钥环"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "需要认证"
+
+#: ../src/gnome/prompter.rs:162
+#, rust-format
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr "有应用程序想要访问密钥环“{}”，但其已锁定"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "解锁"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "新密钥环密码"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "选择新密钥环的密码"
+
+#: ../src/gnome/prompter.rs:184
+#, rust-format
+msgid ""
+"An application wants to create a new keyring called “{}”. Choose the "
+"password you want to use for it."
+msgstr "有应用程序想要创建名称为“{}”的新密钥环。请选择您要对其使用的密码。"
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "创建"


### PR DESCRIPTION
Add translation in Chinese (China) from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/21/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.