### PR TITLE
Add Polish translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -1,4 +1,5 @@
 kk
+pl
 pt_BR
 sl
 uk

--- a/server/po/pl.po
+++ b/server/po/pl.po
@@ -1,0 +1,89 @@
+# Polish translation for oo7.
+# Copyright (C) 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+# Victoria <royal.victoria@proton.me>, 2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-15 03:32+0000\n"
+"PO-Revision-Date: 2026-03-15 12:05+0100\n"
+"Last-Translator: Victoria <royal.victoria@proton.me>\n"
+"Language-Team: Polish\n"
+"Language: pl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2);\n"
+"X-Generator: Gtranslator 49.0\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "Zmiana hasła bazy kluczy"
+
+#: ../src/gnome/prompter.rs:133
+#, rust-format
+msgid "Choose a new password for the “{}” keyring"
+msgstr "Proszę wprowadzić hasło dla nowej bazy kluczy „{}”"
+
+#: ../src/gnome/prompter.rs:136
+#, rust-format
+msgid ""
+"An application wants to change the password for the “{}” keyring. Choose the "
+"new password you want to use for it."
+msgstr ""
+"Program wymaga zmiany hasła dla bazy kluczy „{}”. Należy wprowadzić hasło, "
+"jakie będzie z nią używane."
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "Tego działania nie można cofnąć"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "Kontynuuj"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
+#: ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "Anuluj"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "Odblokowanie bazy kluczy"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "Wymagane jest uwierzytelnienie"
+
+#: ../src/gnome/prompter.rs:162
+#, rust-format
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr "Program wymaga dostępu do bazy kluczy „{}”, ale baza jest zablokowana"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "Odblokuj"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "Hasło nowej bazy kluczy"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "Proszę wprowadzić hasło dla nowej bazy kluczy"
+
+#: ../src/gnome/prompter.rs:184
+#, rust-format
+msgid ""
+"An application wants to create a new keyring called “{}”. Choose the "
+"password you want to use for it."
+msgstr ""
+"Program wymaga utworzenia nowej bazy kluczy o nazwie „{}”. Należy wprowadzić "
+"hasło, jakie będzie z nią używane."
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "Utwórz"


### PR DESCRIPTION
Add translation in Polish from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/73/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.