### PR TITLE
Add Swedish translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -2,5 +2,6 @@ kk
 pl
 pt_BR
 sl
+sv
 uk
 zh_CN

--- a/server/po/sv.po
+++ b/server/po/sv.po
@@ -1,0 +1,84 @@
+# Swedish translation for oo7.
+# Copyright © 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+# Anders Jonsson <anders.jonsson@norsjovallen.se>,  2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-12 15:33+0000\n"
+"PO-Revision-Date: 2026-03-14 20:32+0100\n"
+"Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
+"Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
+"Language: sv\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.8\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "Ändra lösenord för nyckelring"
+
+#: ../src/gnome/prompter.rs:133
+msgid "Choose a new password for the “{}” keyring"
+msgstr "Välj ett nytt lösenord för nyckelringen ”{}”"
+
+#: ../src/gnome/prompter.rs:136
+msgid ""
+"An application wants to change the password for the “{}” keyring. Choose the "
+"new password you want to use for it."
+msgstr ""
+"Ett program vill ändra lösenordet för nyckelringen ”{}”. Välj det nya "
+"lösenord som du vill använda för den."
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "Denna åtgärd kan inte återställas"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "Fortsätt"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
+#: ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "Avbryt"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "Lås upp nyckelring"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "Autentisering krävs"
+
+#: ../src/gnome/prompter.rs:162
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr "Ett program vill komma åt nyckelringen ”{}”, men den är låst"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "Lås upp"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "Lösenord för ny nyckelring"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "Välj lösenord för ny nyckelring"
+
+#: ../src/gnome/prompter.rs:184
+msgid ""
+"An application wants to create a new keyring called “{}”. Choose the "
+"password you want to use for it."
+msgstr ""
+"Ett okänt program vill skapa en ny nyckelring med namnet ”{}”. Välj det "
+"lösenord som du vill använda för den."
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "Skapa"


### PR DESCRIPTION
Add translation in Swedish from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/112/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.