### PR TITLE
Add Serbian translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -6,6 +6,7 @@ kk
 pl
 pt_BR
 sl
+sr
 sv
 uk
 zh_CN

--- a/server/po/sr.po
+++ b/server/po/sr.po
@@ -1,0 +1,80 @@
+# Serbian translation for oo7.
+# Copyright (C) 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+# Марко Костић <marko.m.kostic@gmail.com>,  2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-28 03:31+0000\n"
+"PO-Revision-Date: 2026-03-28 08:25+0100\n"
+"Last-Translator: Марко М. Костић <marko.m.kostic@gmail.com>\n"
+"Language-Team: Serbian <Serbian>\n"
+"Language: sr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=4; plural=n==1? 3 : n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? "
+"1 : 2;\n"
+"X-Generator: Poedit 3.9\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "Промени лозинку привеска"
+
+#: ../src/gnome/prompter.rs:133
+#, rust-format
+msgid "Choose a new password for the “{}” keyring"
+msgstr "Изаберите нову лозинку за привезак „{}“"
+
+#: ../src/gnome/prompter.rs:136
+#, rust-format
+msgid "An application wants to change the password for the “{}” keyring. Choose the new password you want to use for it."
+msgstr "Неки програм жели да промени лозинку за привезак „{}“. Изаберите нову лозинку коју желите да користите."
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "Ова радња се не може поништити"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "Настави"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174 ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "Откажи"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "Откључај привезак"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "Потребна је пријава"
+
+#: ../src/gnome/prompter.rs:162
+#, rust-format
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr "Неки програм жели приступ привеску „{}“, али је он закључан"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "Откључај"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "Лозинка новог привеска"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "Изаберите лозинку за нови привезак"
+
+#: ../src/gnome/prompter.rs:184
+#, rust-format
+msgid "An application wants to create a new keyring called “{}”. Choose the password you want to use for it."
+msgstr "Неки програм жели да направи нови привезак под називом „{}“. Изаберите лозинку коју желите да користите за њега."
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "Направи"


### PR DESCRIPTION
Add translation in Serbian from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/107/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.