### PR TITLE
Add Russian translation

### DIFF
--- a/server/po/LINGUAS
+++ b/server/po/LINGUAS
@@ -6,6 +6,7 @@ it
 kk
 pl
 pt_BR
+ru
 sl
 sr
 sv

--- a/server/po/ru.po
+++ b/server/po/ru.po
@@ -1,0 +1,89 @@
+# Russian translation for oo7.
+# Copyright (C) 2026 oo7's COPYRIGHT HOLDER
+# This file is distributed under the same license as the oo7 package.
+# Artur S0 <arturios05@bk.ru>,  2026.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: oo7 main\n"
+"Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
+"POT-Creation-Date: 2026-03-30 15:32+0000\n"
+"PO-Revision-Date: 2026-03-30 19:52+0300\n"
+"Last-Translator: Artur S0 <arturios2005@mail.ru>\n"
+"Language-Team: Русский <gnome-cyr@gnome.org>\n"
+"Language: ru\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : 2);\n"
+"X-Generator: Poedit 3.9\n"
+
+#: ../src/gnome/prompter.rs:132
+msgid "Change Keyring Password"
+msgstr "Изменить пароль для связки ключей"
+
+#: ../src/gnome/prompter.rs:133
+#, rust-format
+msgid "Choose a new password for the “{}” keyring"
+msgstr "Выберите новый пароль для связки ключей «{}»"
+
+#: ../src/gnome/prompter.rs:136
+#, rust-format
+msgid ""
+"An application wants to change the password for the “{}” keyring. Choose the "
+"new password you want to use for it."
+msgstr ""
+"Приложение хочет изменить пароль для связки ключей «{}». Выберите новый "
+"пароль, который вы хотите использовать для этого приложения."
+
+#: ../src/gnome/prompter.rs:141
+msgid "This operation cannot be reverted"
+msgstr "Эта операция не может быть отменена"
+
+#: ../src/gnome/prompter.rs:147
+msgid "Continue"
+msgstr "Продолжить"
+
+#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
+#: ../src/gnome/prompter.rs:196
+msgid "Cancel"
+msgstr "Отменить"
+
+#: ../src/gnome/prompter.rs:158
+msgid "Unlock Keyring"
+msgstr "Разблокировать связку ключей"
+
+#: ../src/gnome/prompter.rs:159
+msgid "Authentication required"
+msgstr "Требуется аутентификация"
+
+#: ../src/gnome/prompter.rs:162
+#, rust-format
+msgid "An application wants access to the keyring '{}', but it is locked"
+msgstr "Приложение хочет получить доступ к связке ключей «{}», но она заблокирована"
+
+#: ../src/gnome/prompter.rs:173
+msgid "Unlock"
+msgstr "Разблокировать"
+
+#: ../src/gnome/prompter.rs:180
+msgid "New Keyring Password"
+msgstr "Новый пароль для связки ключей"
+
+#: ../src/gnome/prompter.rs:181
+msgid "Choose password for new keyring"
+msgstr "Выберите пароль для новой связки ключей"
+
+#: ../src/gnome/prompter.rs:184
+#, rust-format
+msgid ""
+"An application wants to create a new keyring called “{}”. Choose the "
+"password you want to use for it."
+msgstr ""
+"Приложение хочет создать новую связку ключей с именем «{}». Выберите "
+"пароль, который вы хотите использовать для нее."
+
+#: ../src/gnome/prompter.rs:195
+msgid "Create"
+msgstr "Создать"


### PR DESCRIPTION
Add translation in Russian from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/31/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.