### PR TITLE
cargo: Bump msrv to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ categories = ["os::linux-apis", "os", "api-bindings"]
 repository = "https://github.com/linux-credentials/oo7"
 homepage = "https://github.com/linux-credentials/oo7"
 license = "MIT"
-rust-version = "1.88"
+rust-version = "1.95"
 exclude = ["org.freedesktop.Secrets.xml"]
 
 [workspace.dependencies]

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -866,14 +866,14 @@ fn print_secret_only(secret: &oo7::Secret, as_hex: bool) -> Result<(), Error> {
 // Copy from /client/src/file/api/mod.rs
 fn data_dir() -> Option<PathBuf> {
     std::env::var_os("XDG_DATA_HOME")
-        .and_then(|h| if h.is_empty() { None } else { Some(h) })
+        .filter(|h| !h.is_empty())
         .map(PathBuf::from)
-        .and_then(|p| if p.is_absolute() { Some(p) } else { None })
+        .filter(|p| p.is_absolute())
         .or_else(|| home().map(|p| p.join(".local/share")))
 }
 
 fn home() -> Option<PathBuf> {
     std::env::var_os("HOME")
-        .and_then(|h| if h.is_empty() { None } else { Some(h) })
+        .filter(|h| !h.is_empty())
         .map(PathBuf::from)
 }

--- a/client/src/file/api/mod.rs
+++ b/client/src/file/api/mod.rs
@@ -53,12 +53,12 @@ use crate::{
 
 pub(crate) fn data_dir() -> Option<PathBuf> {
     std::env::var_os("XDG_DATA_HOME")
-        .and_then(|h| if h.is_empty() { None } else { Some(h) })
+        .filter(|h| !h.is_empty())
         .map(PathBuf::from)
-        .and_then(|p| if p.is_absolute() { Some(p) } else { None })
+        .filter(|p| p.is_absolute())
         .or_else(|| {
             std::env::var_os("HOME")
-                .and_then(|h| if h.is_empty() { None } else { Some(h) })
+                .filter(|h| !h.is_empty())
                 .map(PathBuf::from)
                 .map(|p| p.join(".local/share"))
         })

--- a/server/src/item/mod.rs
+++ b/server/src/item/mod.rs
@@ -37,7 +37,7 @@ impl Item {
         else {
             return Err(ServiceError::NoSuchObject(format!(
                 "Collection `{}` does not exist.",
-                &self.collection_path
+                self.collection_path
             )));
         };
 

--- a/server/src/pam_listener/mod.rs
+++ b/server/src/pam_listener/mod.rs
@@ -301,7 +301,7 @@ impl PamListener {
 
         let collections = self.service.collections.lock().await;
 
-        for (_path, collection) in collections.iter() {
+        for collection in collections.values() {
             if collection.is_locked().await {
                 tracing::debug!("Attempting to unlock collection: {}", collection.path());
 

--- a/server/src/service/mod.rs
+++ b/server/src/service/mod.rs
@@ -224,7 +224,7 @@ impl Service {
         let mut locked = Vec::new();
         let collections = self.collections.lock().await;
 
-        for (_path, collection) in collections.iter() {
+        for collection in collections.values() {
             let items = collection.search_inner_items(&attributes).await?;
             for item in items {
                 if item.is_locked().await {
@@ -334,7 +334,7 @@ impl Service {
                         // Try to find as item within collections
                         let collections = service.collections.lock().await;
                         let mut found_collection = None;
-                        for (_path, collection) in collections.iter() {
+                        for collection in collections.values() {
                             if let Some(item) = collection.item_from_path(object).await {
                                 found_collection = Some((
                                     collection.clone(),
@@ -410,7 +410,7 @@ impl Service {
         let mut secrets = HashMap::new();
         let collections = self.collections.lock().await;
 
-        'outer: for (_path, collection) in collections.iter() {
+        'outer: for collection in collections.values() {
             for item in &items {
                 if let Some(item) = collection.item_from_path(item).await {
                     match item.get_secret(session.clone()).await {
@@ -566,12 +566,12 @@ impl Service {
     pub async fn run(secret: Option<Secret>, request_replacement: bool) -> Result<(), Error> {
         // Compute data directory from environment variables
         let data_dir = std::env::var_os("XDG_DATA_HOME")
-            .and_then(|h| if h.is_empty() { None } else { Some(h) })
+            .filter(|h| !h.is_empty())
             .map(std::path::PathBuf::from)
-            .and_then(|p| if p.is_absolute() { Some(p) } else { None })
+            .filter(|p| p.is_absolute())
             .or_else(|| {
                 std::env::var_os("HOME")
-                    .and_then(|h| if h.is_empty() { None } else { Some(h) })
+                    .filter(|h| !h.is_empty())
                     .map(std::path::PathBuf::from)
                     .map(|p| p.join(".local/share"))
             })


### PR DESCRIPTION
git-credentials-oo7 uses a if-let guard which were [introduced](https://blog.rust-lang.org/2026/04/16/Rust-1.95.0/#if-let-guards-in-matches) in 1.95.