### PR TITLE
docs: fix `gnome-portals.conf` code block language

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ the `portals.conf(5)` man page.
 This can be achieved by creating a file at
 `~/.config/xdg-desktop-portal/gnome-portals.conf` with contents:
 
-``` toml
+```desktop
 [preferred]
 default=gnome;gtk;
 org.freedesktop.impl.portal.Secret=oo7-portal;gnome-keyring;


### PR DESCRIPTION
I went down a tiny rabbit hole due to noticing the red/error text in the README example. I noticed the code block marked as `toml`, which seemed incorrect as I believed the file to use INI syntax, which the `portals.conf` manual confirms:

> The  format  of the portals configuration file is the same .ini format used by systemd unit files or application desktop files.

The systemd unit files syntax manual itself confirms that their syntax is inspired by desktop files:

> The syntax is inspired by XDG Desktop Entry Specification[1] .desktop files, which are in turn inspired by Microsoft Windows .ini files.

GitHub seems to support `desktop` for the language, which renders most correctly (with `ini`, semicolon separators appear as comments):

| `toml` | `ini`/`conf` | `desktop` |
| --- | --- | --- |
| <img width="512" height="80" alt="Screenshot From 2026-07-13 15-51-15" src="https://github.com/user-attachments/assets/a4f655f1-59d4-4d53-9e8a-c693e6635962" /> | <img width="512" height="80" alt="Screenshot From 2026-07-13 15-51-31" src="https://github.com/user-attachments/assets/46c9d55f-96e6-4d67-a958-96256eafa581" /> | <img width="512" height="80" alt="Screenshot From 2026-07-13 15-51-43" src="https://github.com/user-attachments/assets/d17bb304-7e11-4734-9ba0-93acdba88ade" /> |

I hope you don't mind this incredibly nit PR. :joy: 