### PR TITLE
Server: Properly deduplicate string

### DIFF
--- a/server/src/gnome/prompter.rs
+++ b/server/src/gnome/prompter.rs
@@ -178,7 +178,7 @@ impl Properties {
             message: Some(gettext("Authentication required")),
             description: Some(
                 formatx!(
-                    gettext("An application wants access to the keyring '{}', but it is locked",),
+                    gettext("An application wants access to the keyring “{}”, but it is locked",),
                     keyring,
                 )
                 .expect("Wrong format in translatable string"),


### PR DESCRIPTION
In #521 I accidentally introduced new string. This commit fixes this. 