### PR TITLE
client: Accept `application/json` as `Text`

### DIFF
--- a/client/src/secret.rs
+++ b/client/src/secret.rs
@@ -42,6 +42,7 @@ impl FromStr for ContentType {
 
         if media_type.eq_ignore_ascii_case("text/plain")
             || media_type.eq_ignore_ascii_case("text/utf8")
+            || media_type.eq_ignore_ascii_case("application/json")
         {
             Ok(Self::Text)
         } else if media_type.eq_ignore_ascii_case("application/octet-stream") {
@@ -252,6 +253,11 @@ mod tests {
         let content_type: ContentType = encoded.deserialize().unwrap().0;
         assert_eq!(content_type, ContentType::Blob);
 
+        // application/json deserializes as Text
+        let encoded = to_bytes(ctxt, &"application/json").unwrap();
+        let content_type: ContentType = encoded.deserialize().unwrap().0;
+        assert_eq!(content_type, ContentType::Text);
+
         // Test invalid content type deserialization
         let encoded = to_bytes(ctxt, &"invalid/type").unwrap();
         let result: Result<(ContentType, _), _> = encoded.deserialize();
@@ -270,6 +276,8 @@ mod tests {
             "text/plain",
             "text/plain; charset=utf8",
             "TEXT/PLAIN; CHARSET=UTF-8",
+            "application/json",
+            "application/json; charset=utf8",
         ] {
             assert_eq!(
                 ContentType::from_str(content_type).unwrap(),


### PR DESCRIPTION
`ContentType` currently does not accept `application/json` MIME type, which breaks apps like [aws-vault](https://github.com/ByteNess/aws-vault). 

This PR adds `application/json` as an acceptable `Text` secret (since JSON is always a valid UTF-8) and keeps the Text/Blob distinction and MIME parameter parsing intact.

Tested with `aws-vault` in my NixOS setup:
- Adding secret with it no longer throws `aws-vault: error: add: Invalid content type: application/json`
- Exporting secret and requesting STS token through it works normally

A more generic fix for this type of errors might be to map every unrecognized content type to `Blob` instead of rejecting them. 

Let me know what you think!