### PR TITLE
Update Kazakh translation

### DIFF
--- a/server/po/kk.po
+++ b/server/po/kk.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: oo7 main\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
-"POT-Creation-Date: 2026-03-14 15:32+0000\n"
-"PO-Revision-Date: 2026-03-14 22:27+0500\n"
+"POT-Creation-Date: 2026-07-29 03:37+0000\n"
+"PO-Revision-Date: 2026-07-29 11:38+0500\n"
 "Last-Translator: Baurzhan Muftakhidinov <baurthefirst@gmail.com>\n"
 "Language-Team: Kazakh <Kazakh>\n"
 "Language: kk\n"
@@ -17,16 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#: ../src/gnome/prompter.rs:132
+#: ../src/gnome/prompter.rs:151
 msgid "Change Keyring Password"
 msgstr "Кілттер бауының паролін өзгерту"
 
-#: ../src/gnome/prompter.rs:133
+#: ../src/gnome/prompter.rs:152
 #, rust-format
 msgid "Choose a new password for the “{}” keyring"
 msgstr "«{}» кілттер бауы үшін жаңа парольді таңдаңыз"
 
-#: ../src/gnome/prompter.rs:136
+#: ../src/gnome/prompter.rs:155 ../src/prompt/mod.rs:396
 #, rust-format
 msgid ""
 "An application wants to change the password for the “{}” keyring. Choose "
@@ -35,46 +35,46 @@ msgstr ""
 "Қолданба «{}» кілттер бауының паролін өзгерткісі келеді. Ол үшін "
 "қолданылатын жаңа парольді таңдаңыз."
 
-#: ../src/gnome/prompter.rs:141
+#: ../src/gnome/prompter.rs:160
 msgid "This operation cannot be reverted"
 msgstr "Бұл әрекетті болдырмау мүмкін емес"
 
-#: ../src/gnome/prompter.rs:147
+#: ../src/gnome/prompter.rs:166
 msgid "Continue"
 msgstr "Жалғастыру"
 
-#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
-#: ../src/gnome/prompter.rs:196
+#: ../src/gnome/prompter.rs:167 ../src/gnome/prompter.rs:193
+#: ../src/gnome/prompter.rs:215
 msgid "Cancel"
 msgstr "Бас тарту"
 
-#: ../src/gnome/prompter.rs:158
+#: ../src/gnome/prompter.rs:177
 msgid "Unlock Keyring"
 msgstr "Кілттер бауының құлпын ашу"
 
-#: ../src/gnome/prompter.rs:159
+#: ../src/gnome/prompter.rs:178
 msgid "Authentication required"
 msgstr "Аутентификация қажет"
 
-#: ../src/gnome/prompter.rs:162
+#: ../src/gnome/prompter.rs:181 ../src/prompt/mod.rs:386
 #, rust-format
-msgid "An application wants access to the keyring '{}', but it is locked"
+msgid "An application wants access to the keyring “{}”, but it is locked"
 msgstr ""
-"Қолданба '{}' кілттер бауына қол жеткізгісі келеді, бірақ ол құлыпталған"
+"Қолданба «{}» кілттер бауына қол жеткізуді қалайды, бірақ ол құлыпталған"
 
-#: ../src/gnome/prompter.rs:173
+#: ../src/gnome/prompter.rs:192
 msgid "Unlock"
 msgstr "Құлпын ашу"
 
-#: ../src/gnome/prompter.rs:180
+#: ../src/gnome/prompter.rs:199
 msgid "New Keyring Password"
 msgstr "Кілттер бауының жаңа паролі"
 
-#: ../src/gnome/prompter.rs:181
+#: ../src/gnome/prompter.rs:200
 msgid "Choose password for new keyring"
 msgstr "Жаңа кілттер бауы үшін парольді таңдаңыз"
 
-#: ../src/gnome/prompter.rs:184
+#: ../src/gnome/prompter.rs:203 ../src/prompt/mod.rs:391
 #, rust-format
 msgid ""
 "An application wants to create a new keyring called “{}”. Choose the "
@@ -83,6 +83,6 @@ msgstr ""
 "Қолданба «{}» деп аталатын жаңа кілттер бауын жасағысы келеді. Ол үшін "
 "қолданылатын парольді таңдаңыз."
 
-#: ../src/gnome/prompter.rs:195
+#: ../src/gnome/prompter.rs:214
 msgid "Create"
 msgstr "Жасау"


### PR DESCRIPTION
Update translation in Kazakh from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/106/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.