### PR TITLE
Lack of proper linking during the build process

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,6 +54,11 @@ jobs:
         run: |
           cargo build --manifest-path ./server/Cargo.toml --no-default-features --features openssl_crypto
 
+      - name: Install PAM headers
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libpam0g-dev
+
       - name: Build PAM
         run: |
           cargo build --manifest-path ./pam/Cargo.toml
@@ -124,7 +129,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Install dependencies
-        run: dnf install -y git meson gcc systemd
+        run: dnf install -y git meson gcc systemd pam-devel
       - name: Build (portal)
         working-directory: ./portal
         run: meson setup ./ _build --prefix /usr && ninja -C _build

--- a/pam/build.rs
+++ b/pam/build.rs
@@ -1,0 +1,11 @@
+use std::env::var_os;
+
+fn main() {
+    if var_os("DOCS_RS").is_some() {
+        // libpam isn't available on docs.rs, and we don't need to link
+        // against it to build the documentation.
+        return;
+    }
+
+    println!("cargo::rustc-link-lib=pam");
+}

--- a/pam/src/ffi.rs
+++ b/pam/src/ffi.rs
@@ -30,7 +30,6 @@ pub struct pam_handle_t {
     _private: [u8; 0],
 }
 
-#[link(name = "pam")]
 unsafe extern "C" {
     /// Get the username
     pub fn pam_get_user(

--- a/pam/src/ffi.rs
+++ b/pam/src/ffi.rs
@@ -30,6 +30,7 @@ pub struct pam_handle_t {
     _private: [u8; 0],
 }
 
+#[link(name = "pam")]
 unsafe extern "C" {
     /// Get the username
     pub fn pam_get_user(


### PR DESCRIPTION
The PAM module didn't specify #[link(name = "pam")] in the extern "C" block, so the linker never emitted -lpam. PAM then failed to dlopen the module with undefined symbol errors for pam_get_item, pam_get_user, pam_set_data, and pam_get_data.

**Please** either add this yourself or accept a PR to prevent this from happening again and ensure PAM authentication works properly