### PR TITLE
Update Swedish translation

### DIFF
--- a/server/po/sv.po
+++ b/server/po/sv.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: oo7 main\n"
 "Report-Msgid-Bugs-To: https://github.com/linux-credentials/oo7/issues\n"
-"POT-Creation-Date: 2026-03-12 15:33+0000\n"
-"PO-Revision-Date: 2026-03-14 20:32+0100\n"
+"POT-Creation-Date: 2026-07-15 15:38+0000\n"
+"PO-Revision-Date: 2026-08-12 02:06+0200\n"
 "Last-Translator: Anders Jonsson <anders.jonsson@norsjovallen.se>\n"
 "Language-Team: Swedish <tp-sv@listor.tp-sv.se>\n"
 "Language: sv\n"
@@ -16,17 +16,19 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.8\n"
+"X-Generator: Poedit 3.9\n"
 
-#: ../src/gnome/prompter.rs:132
+#: ../src/gnome/prompter.rs:151
 msgid "Change Keyring Password"
 msgstr "Ändra lösenord för nyckelring"
 
-#: ../src/gnome/prompter.rs:133
+#: ../src/gnome/prompter.rs:152
+#, rust-format
 msgid "Choose a new password for the “{}” keyring"
 msgstr "Välj ett nytt lösenord för nyckelringen ”{}”"
 
-#: ../src/gnome/prompter.rs:136
+#: ../src/gnome/prompter.rs:155 ../src/prompt/mod.rs:396
+#, rust-format
 msgid ""
 "An application wants to change the password for the “{}” keyring. Choose the "
 "new password you want to use for it."
@@ -34,44 +36,46 @@ msgstr ""
 "Ett program vill ändra lösenordet för nyckelringen ”{}”. Välj det nya "
 "lösenord som du vill använda för den."
 
-#: ../src/gnome/prompter.rs:141
+#: ../src/gnome/prompter.rs:160
 msgid "This operation cannot be reverted"
 msgstr "Denna åtgärd kan inte återställas"
 
-#: ../src/gnome/prompter.rs:147
+#: ../src/gnome/prompter.rs:166
 msgid "Continue"
 msgstr "Fortsätt"
 
-#: ../src/gnome/prompter.rs:148 ../src/gnome/prompter.rs:174
-#: ../src/gnome/prompter.rs:196
+#: ../src/gnome/prompter.rs:167 ../src/gnome/prompter.rs:193
+#: ../src/gnome/prompter.rs:215
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: ../src/gnome/prompter.rs:158
+#: ../src/gnome/prompter.rs:177
 msgid "Unlock Keyring"
 msgstr "Lås upp nyckelring"
 
-#: ../src/gnome/prompter.rs:159
+#: ../src/gnome/prompter.rs:178
 msgid "Authentication required"
 msgstr "Autentisering krävs"
 
-#: ../src/gnome/prompter.rs:162
-msgid "An application wants access to the keyring '{}', but it is locked"
+#: ../src/gnome/prompter.rs:181 ../src/prompt/mod.rs:386
+#, rust-format
+msgid "An application wants access to the keyring “{}”, but it is locked"
 msgstr "Ett program vill komma åt nyckelringen ”{}”, men den är låst"
 
-#: ../src/gnome/prompter.rs:173
+#: ../src/gnome/prompter.rs:192
 msgid "Unlock"
 msgstr "Lås upp"
 
-#: ../src/gnome/prompter.rs:180
+#: ../src/gnome/prompter.rs:199
 msgid "New Keyring Password"
 msgstr "Lösenord för ny nyckelring"
 
-#: ../src/gnome/prompter.rs:181
+#: ../src/gnome/prompter.rs:200
 msgid "Choose password for new keyring"
 msgstr "Välj lösenord för ny nyckelring"
 
-#: ../src/gnome/prompter.rs:184
+#: ../src/gnome/prompter.rs:203 ../src/prompt/mod.rs:391
+#, rust-format
 msgid ""
 "An application wants to create a new keyring called “{}”. Choose the "
 "password you want to use for it."
@@ -79,6 +83,6 @@ msgstr ""
 "Ett okänt program vill skapa en ny nyckelring med namnet ”{}”. Välj det "
 "lösenord som du vill använda för den."
 
-#: ../src/gnome/prompter.rs:195
+#: ../src/gnome/prompter.rs:214
 msgid "Create"
 msgstr "Skapa"


### PR DESCRIPTION
Update translation in Swedish from Damned Lies: https://l10n.gnome.org/vertimus/7464/1815/112/. Maintainers, the translation has gone through the Damned Lies review process and is ready to be included in the main repository. It has been reviewed by the language team.