### PR TITLE
Port to zgvariant

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1158,6 +1158,7 @@ dependencies = [
  "zbus",
  "zbus_macros",
  "zeroize",
+ "zgvariant",
  "zvariant",
 ]
 
@@ -2371,6 +2372,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "zgvariant"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60f1fd025a5215c4071378b7660d019b5588210c8645fb01f99fe30ecb382923"
+dependencies = [
+ "endi",
+ "serde",
+ "serde_bytes",
+ "winnow",
+ "zcheapstr",
+ "zgvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zgvariant_derive"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e85114cc9a835a222b21d5be18e488d7eb3c41a66c9be4ec9b9b58b94b9e5b8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,9 +2435,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "4.0.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "629d80ece222cad20fe0e8741be493c4ab166acf3b85341bdc2cdbcfd8f3c2d6"
+checksum = "6b84ebb462416c27cdb97f2e7f5f0ccc844da1fe2ecc7121e1b690b41318bf42"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,10 +1156,8 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "zbus",
- "zbus_macros",
  "zeroize",
  "zgvariant",
- "zvariant",
 ]
 
 [[package]]
@@ -1210,6 +1208,7 @@ dependencies = [
  "tracing-subscriber",
  "zbus",
  "zeroize",
+ "zgvariant",
 ]
 
 [[package]]
@@ -1234,7 +1233,7 @@ dependencies = [
  "tracing-journald",
  "tracing-subscriber",
  "zeroize",
- "zvariant",
+ "zgvariant",
 ]
 
 [[package]]
@@ -2406,14 +2405,13 @@ checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zvariant"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+checksum = "c1d34c27cc6cdd1f458427519dd6b8612f7b7e3f7b9a0b2355d041dda9869147"
 dependencies = [
  "endi",
  "enumflags2",
  "serde",
- "serde_bytes",
  "winnow",
  "zcheapstr",
  "zvariant_derive",
@@ -2422,9 +2420,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_derive"
-version = "5.14.0"
+version = "5.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+checksum = "864155e69b4352db0c7f374917bf45d1e0c8d17659c8b3dbf9795f3673f8c497"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -2435,9 +2433,9 @@ dependencies = [
 
 [[package]]
 name = "zvariant_utils"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b84ebb462416c27cdb97f2e7f5f0ccc844da1fe2ecc7121e1b690b41318bf42"
+checksum = "bad0294361a320b694a328460dc73add56c306150f5cb6bfafc44446120008a3"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,8 @@ tempfile = "3.26"
 tokio = { version = "1.52", default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"
-zbus = { version = "5.14.0", default-features = false }
-zbus_macros = { version = "5.11", features = ["gvariant"] }
+zbus = { version = "5.19", default-features = false }
+zgvariant = { version = "1.0", features = ["serde_bytes"] }
+zbus_macros = { version = "5.19", features = ["gvariant"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5.8", default-features = false, features = ["gvariant", "serde_bytes"] }
+zvariant = { version = "5.14", default-features = false, features = ["gvariant", "serde_bytes"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,4 @@ tracing = "0.1"
 tracing-subscriber = "0.3"
 zbus = { version = "5.19", default-features = false }
 zgvariant = { version = "1.0", features = ["serde_bytes"] }
-zbus_macros = { version = "5.19", features = ["gvariant"] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5.14", default-features = false, features = ["gvariant", "serde_bytes"] }

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -43,8 +43,6 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true, optional = true }
 zgvariant.workspace = true
 zbus.workspace = true
-zbus_macros.workspace = true
-zvariant.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { workspace = true, features = [
     "io-util",
 ], optional = true, default-features = false }
 tracing = { workspace = true, optional = true }
+zgvariant.workspace = true
 zbus.workspace = true
 zbus_macros.workspace = true
 zvariant.workspace = true

--- a/client/src/dbus/algorithm.rs
+++ b/client/src/dbus/algorithm.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use zbus::zvariant;
 
 #[derive(Debug, zvariant::Type, PartialEq, Eq, Copy, Clone)]
 #[zvariant(signature = "s")]
@@ -43,7 +44,7 @@ impl<'de> Deserialize<'de> for Algorithm {
 
 #[cfg(test)]
 mod tests {
-    use zvariant::{Endian, serialized::Context, to_bytes};
+    use zbus::zvariant::{Endian, serialized::Context, to_bytes};
 
     use super::*;
 

--- a/client/src/dbus/api/properties.rs
+++ b/client/src/dbus/api/properties.rs
@@ -4,7 +4,7 @@ use serde::{
     Deserialize,
     ser::{Serialize, SerializeMap},
 };
-use zbus::zvariant::{Type, Value};
+use zbus::zvariant::{self, Type, Value};
 
 use crate::AsAttributes;
 
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn deserialize_item_properties() {
-        use zvariant::Dict;
+        use zbus::zvariant::Dict;
 
         // Create serialized data that represents item properties
         let mut attrs_dict = Dict::new(String::SIGNATURE, String::SIGNATURE);

--- a/client/src/dbus/api/service.rs
+++ b/client/src/dbus/api/service.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, fmt};
 
 use ashpd::WindowIdentifier;
 use futures_util::{Stream, StreamExt};
-use zbus::zvariant::{ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
+use zbus::zvariant::{self, ObjectPath, OwnedObjectPath, OwnedValue, Type, Value};
 
 use super::{
     Collection, DBusSecret, DESTINATION, Item, PATH, Prompt, Properties, Session, Unlockable,

--- a/client/src/file/api/encrypted_item.rs
+++ b/client/src/file/api/encrypted_item.rs
@@ -1,8 +1,8 @@
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
-use zbus::zvariant::Type;
 use zeroize::{Zeroize, ZeroizeOnDrop};
+use zgvariant::Type;
 
 use super::{Error, UnlockedItem};
 use crate::{AsAttributes, Key, Mac, crypto};

--- a/client/src/file/api/mod.rs
+++ b/client/src/file/api/mod.rs
@@ -21,7 +21,7 @@ use futures_lite::AsyncWriteExt;
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "tokio")]
 use tokio::{fs, io, io::AsyncWriteExt};
-use zbus::zvariant::{Endian, Type, serialized::Context};
+use zgvariant::{Type, serialized::Context};
 
 /// Used for newly created [`Keyring`]s
 const DEFAULT_ITERATION_COUNT: u32 = 100000;
@@ -65,7 +65,7 @@ pub(crate) fn data_dir() -> Option<PathBuf> {
 }
 
 pub(crate) static GVARIANT_ENCODING: LazyLock<Context> =
-    LazyLock::new(|| Context::new_gvariant(Endian::Little, 0));
+    LazyLock::new(|| Context::new(zgvariant::LE, 0));
 
 /// Logical contents of a keyring file
 #[derive(Deserialize, Serialize, Type, Debug, Zeroize, ZeroizeOnDrop)]
@@ -257,7 +257,7 @@ impl Keyring {
 
         blob.push(MAJOR_VERSION);
         blob.push(MINOR_VERSION);
-        blob.append(&mut zvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec());
+        blob.append(&mut zgvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec());
 
         Ok(blob)
     }
@@ -373,7 +373,7 @@ impl TryFrom<&[u8]> for Keyring {
         }
 
         if let Some(data) = value.get((FILE_HEADER_LEN + 2)..) {
-            let keyring: Self = zvariant::serialized::Data::new(data, *GVARIANT_ENCODING)
+            let keyring: Self = zgvariant::serialized::Data::new(data, *GVARIANT_ENCODING)
                 .deserialize()?
                 .0;
 

--- a/client/src/file/error.rs
+++ b/client/src/file/error.rs
@@ -10,7 +10,7 @@ pub enum Error {
     /// No Parent directory.
     NoParentDir(String),
     /// Bytes don't have the expected GVariant format.
-    GVariantDeserialization(zvariant::Error),
+    GVariantDeserialization(zgvariant::Error),
     /// Mismatch between array length and length explicitly stored in keyring
     SaltSizeMismatch(usize, u32),
     /// Key for some reason too weak to trust it for writing
@@ -51,8 +51,8 @@ pub enum Error {
     Schema(crate::SchemaError),
 }
 
-impl From<zvariant::Error> for Error {
-    fn from(value: zvariant::Error) -> Self {
+impl From<zgvariant::Error> for Error {
+    fn from(value: zgvariant::Error) -> Self {
         Self::GVariantDeserialization(value)
     }
 }

--- a/client/src/file/unlocked_item.rs
+++ b/client/src/file/unlocked_item.rs
@@ -11,7 +11,7 @@ use crate::{AsAttributes, CONTENT_TYPE_ATTRIBUTE, Key, Mac, Secret, crypto, secr
 
 /// An item stored in the file backend.
 #[derive(
-    Deserialize, Serialize, zvariant::Type, Clone, Debug, Zeroize, ZeroizeOnDrop, PartialEq,
+    Deserialize, Serialize, zgvariant::Type, Clone, Debug, Zeroize, ZeroizeOnDrop, PartialEq,
 )]
 pub struct UnlockedItem {
     #[zeroize(skip)]
@@ -182,7 +182,7 @@ impl UnlockedItem {
     }
 
     fn encrypt_plaintext(&self) -> Result<EncryptedItem, Error> {
-        let blob = zvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec();
+        let blob = zgvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec();
         Ok(EncryptedItem {
             hashed_attributes: self
                 .attributes
@@ -194,7 +194,7 @@ impl UnlockedItem {
     }
 
     fn encrypt_encrypted(&self, key: &Key, iv: &[u8]) -> Result<EncryptedItem, Error> {
-        let decrypted = Zeroizing::new(zvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec());
+        let decrypted = Zeroizing::new(zgvariant::to_bytes(*GVARIANT_ENCODING, &self)?.to_vec());
 
         let mut blob = crypto::encrypt(&*decrypted, key, iv)?;
 
@@ -219,7 +219,7 @@ impl TryFrom<&[u8]> for UnlockedItem {
     type Error = Error;
 
     fn try_from(value: &[u8]) -> Result<Self, Error> {
-        let mut item: UnlockedItem = zvariant::serialized::Data::new(value, *GVARIANT_ENCODING)
+        let mut item: UnlockedItem = zgvariant::serialized::Data::new(value, *GVARIANT_ENCODING)
             .deserialize()?
             .0;
 

--- a/client/src/key.rs
+++ b/client/src/key.rs
@@ -1,3 +1,4 @@
+use zbus::zvariant;
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{crypto, file};

--- a/client/src/mac.rs
+++ b/client/src/mac.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 #[cfg(feature = "native_crypto")]
 use subtle::ConstantTimeEq;
-use zbus::zvariant::Type;
 use zeroize::{Zeroize, ZeroizeOnDrop};
+use zgvariant::Type;
 
 // There is no constructor to avoid performing sanity checks, e.g. length.
 /// A message authentication code. It provides constant-time comparison when

--- a/client/src/secret.rs
+++ b/client/src/secret.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
+use zbus::zvariant;
 use zeroize::{Zeroize, ZeroizeOnDrop, Zeroizing};
 
 #[derive(Default, PartialEq, Eq, Copy, Clone, Debug, zvariant::Type)]
@@ -211,7 +212,7 @@ impl AsRef<[u8]> for Secret {
 
 #[cfg(test)]
 mod tests {
-    use zvariant::{Endian, serialized::Context, to_bytes};
+    use zbus::zvariant::{Endian, serialized::Context, to_bytes};
 
     use super::*;
 

--- a/pam/Cargo.toml
+++ b/pam/Cargo.toml
@@ -22,7 +22,7 @@ tracing.workspace = true
 tracing-journald = "0.3"
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 zeroize.workspace = true
-zvariant.workspace = true
+zgvariant.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/pam/src/protocol.rs
+++ b/pam/src/protocol.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use serde_repr::{Deserialize_repr, Serialize_repr};
 use zeroize::{Zeroize, ZeroizeOnDrop};
-use zvariant::{Type, serialized::Context, to_bytes};
+use zgvariant::{Type, serialized::Context, to_bytes};
 
 #[derive(Debug, Clone, Copy, Serialize_repr, Deserialize_repr, Type, PartialEq, Eq)]
 #[repr(u8)]
@@ -40,15 +40,15 @@ impl PamMessage {
         }
     }
 
-    pub fn to_bytes(&self) -> Result<Vec<u8>, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
+    pub fn to_bytes(&self) -> Result<Vec<u8>, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
         to_bytes(ctxt, self).map(|data| data.to_vec())
     }
 
     #[cfg(test)]
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
-        let data = zvariant::serialized::Data::new(bytes, ctxt);
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
+        let data = zgvariant::serialized::Data::new(bytes, ctxt);
         data.deserialize().map(|(msg, _)| msg)
     }
 }
@@ -60,9 +60,9 @@ pub struct PamResponse {
 }
 
 impl PamResponse {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
-        let data = zvariant::serialized::Data::new(bytes, ctxt);
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
+        let data = zgvariant::serialized::Data::new(bytes, ctxt);
         data.deserialize().map(|(msg, _)| msg)
     }
 }

--- a/pam/src/socket.rs
+++ b/pam/src/socket.rs
@@ -56,7 +56,7 @@ impl Drop for SavedSignals {
 pub enum SocketError {
     Connect(io::Error),
     Send(io::Error),
-    Serialize(zvariant::Error),
+    Serialize(zgvariant::Error),
     Timeout,
     InvalidSocket(String),
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -49,6 +49,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 zbus = { workspace = true, features = ["p2p"] }
 zeroize.workspace = true
+zgvariant.workspace = true
 
 [features]
 test-util = ["dep:tempfile"]

--- a/server/src/pam_listener/mod.rs
+++ b/server/src/pam_listener/mod.rs
@@ -10,11 +10,11 @@ use tokio::{
     net::{UnixListener, UnixStream},
     sync::RwLock,
 };
-use zbus::zvariant::{
+use zeroize::{Zeroize, ZeroizeOnDrop};
+use zgvariant::{
     self, Type,
     serialized::{Context, Data},
 };
-use zeroize::{Zeroize, ZeroizeOnDrop};
 
 use crate::{Service, error::Error};
 
@@ -41,8 +41,8 @@ struct PamResponse {
 }
 
 impl PamMessage {
-    fn from_bytes(bytes: &[u8]) -> Result<Self, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
+    fn from_bytes(bytes: &[u8]) -> Result<Self, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
         let data = Data::new(bytes, ctxt);
         data.deserialize().map(|(msg, _)| msg)
     }
@@ -64,15 +64,15 @@ impl PamResponse {
     }
 
     #[cfg(test)]
-    fn from_bytes(bytes: &[u8]) -> Result<Self, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
+    fn from_bytes(bytes: &[u8]) -> Result<Self, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
         let data = Data::new(bytes, ctxt);
         data.deserialize().map(|(msg, _)| msg)
     }
 
-    fn to_bytes(&self) -> Result<Vec<u8>, zvariant::Error> {
-        let ctxt = Context::new_dbus(zvariant::LE, 0);
-        let encoded = zvariant::to_bytes(ctxt, self)?;
+    fn to_bytes(&self) -> Result<Vec<u8>, zgvariant::Error> {
+        let ctxt = Context::new(zgvariant::LE, 0);
+        let encoded = zgvariant::to_bytes(ctxt, self)?;
         let message_bytes = encoded.to_vec();
 
         // Prepend length prefix (4 bytes, little-endian)

--- a/server/src/pam_listener/tests.rs
+++ b/server/src/pam_listener/tests.rs
@@ -1,5 +1,5 @@
 use oo7::file::UnlockedKeyring;
-use zbus::zvariant::serialized::Context;
+use zgvariant::serialized::Context;
 
 use super::*;
 
@@ -16,8 +16,8 @@ fn create_pam_message(
         new_secret: new_secret.to_vec(),
     };
 
-    let ctxt = Context::new_dbus(zvariant::LE, 0);
-    let encoded = zvariant::to_bytes(ctxt, &message).unwrap();
+    let ctxt = Context::new(zgvariant::LE, 0);
+    let encoded = zgvariant::to_bytes(ctxt, &message).unwrap();
     let message_bytes = encoded.to_vec();
 
     // Prepend length prefix (4 bytes, little-endian)
@@ -307,8 +307,8 @@ async fn message_serialization() -> Result<(), Box<dyn std::error::Error>> {
         new_secret: b"my-password".to_vec(),
     };
 
-    let ctxt = Context::new_dbus(zvariant::LE, 0);
-    let encoded = zvariant::to_bytes(ctxt, &message)?;
+    let ctxt = Context::new(zgvariant::LE, 0);
+    let encoded = zgvariant::to_bytes(ctxt, &message)?;
     let decoded = PamMessage::from_bytes(&encoded)?;
 
     assert_eq!(decoded.operation, PamOperation::Unlock);
@@ -322,8 +322,8 @@ async fn message_serialization() -> Result<(), Box<dyn std::error::Error>> {
         new_secret: b"new-pass".to_vec(),
     };
 
-    let ctxt = Context::new_dbus(zvariant::LE, 0);
-    let encoded = zvariant::to_bytes(ctxt, &message)?;
+    let ctxt = Context::new(zgvariant::LE, 0);
+    let encoded = zgvariant::to_bytes(ctxt, &message)?;
     let decoded = PamMessage::from_bytes(&encoded)?;
 
     assert_eq!(decoded.operation, PamOperation::ChangePassword);


### PR DESCRIPTION
Supersedes #550.

Moves oo7's GVariant usage off the (now-deprecated) `zvariant/gvariant` feature onto the
standalone [`zgvariant`](https://crates.io/crates/zgvariant) crate:

- `client` uses `zgvariant` for the keyring **file** format, and reaches the D-Bus zvariant
  through `zbus::zvariant` (the same instance ashpd re-exports).
- The pam module ⇄ daemon socket protocol is an internal wire format (not real D-Bus), so it now
  uses the GVariant encoding via `zgvariant` on both ends — the pam module and the daemon's
  `pam_listener`. This drops zvariant from the pam module entirely; it now depends only on
  `zgvariant`.

Requires zvariant 5.15.0 / zvariant_utils 4.2.0 — the coexistence fix that lets zvariant's D-Bus
format and zgvariant's GVariant format share one build — now published, so the tree resolves
purely from crates.io.

Verified locally: the whole workspace builds, the pam and daemon `pam_listener` round-trip tests
pass (they exercise the socket wire format end-to-end), and clippy + rustfmt are clean.

Generated by Claude Opus 4.8 (claude-opus-4-8).
